### PR TITLE
Remove warnings for JuMP ≥ 0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "OptimizationProblems"
 uuid = "5049e819-d29b-5fba-b941-0eee7e64c1c6"
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 
 [compat]
-JuMP = "~0.15, ~0.16, ~0.17, ~0.18"
+JuMP = "~0.19, ~0.20, ~0.21"
 julia = "~1"
 
 [extras]

--- a/src/chainwoo.jl
+++ b/src/chainwoo.jl
@@ -33,10 +33,10 @@ function chainwoo(n :: Int=100)
   # @variable(nlp, x[i=1:n], start=[-3 ; -1 ; -3 ; -1 ; -2 * ones(n-4)])
 
   @variable(nlp, x[i=1:n], start=-2)
-  setvalue(x[1], -3)
-  setvalue(x[2], -1)
-  setvalue(x[3], -3)
-  setvalue(x[4], -1)
+  set_start_value(x[1], -3)
+  set_start_value(x[2], -1)
+  set_start_value(x[3], -3)
+  set_start_value(x[4], -1)
 
   @NLobjective(
     nlp,

--- a/src/cragglvy.jl
+++ b/src/cragglvy.jl
@@ -36,7 +36,7 @@ function cragglvy(n :: Int=100)
   # @variable(nlp, x[i=1:n], start=[1 ; 2 * ones(n-1)])
 
   @variable(nlp, x[i=1:n], start=2)
-  setvalue(x[1], 1)
+  set_start_value(x[1], 1)
 
   @NLobjective(
     nlp,


### PR DESCRIPTION
When a release `0.2` is done for `OptimizationProblems.jl` you can merge this pull request.
It will help us to do the transition between MPB / MOI.
Version `0.2` will be automatically installed if a package needs MPB / JuMP 0.18 otherwise version `0.3` will be installed. 