### PR TITLE
Add folder and problems for ADNLPs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ task:
   name: FreeBSD
   env:
     matrix:
-      - JULIA_VERSION: 1.0
+      - JULIA_VERSION: 1.3
       - JULIA_VERSION: 1
       - JULIA_VERSION: nightly
   allow_failures: $JULIA_VERSION == 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -3,18 +3,18 @@ uuid = "5049e819-d29b-5fba-b941-0eee7e64c1c6"
 version = "0.3.0"
 
 [deps]
-ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-ADNLPModels = "0.3"
 JuMP = "~0.19, ~0.20, ~0.21"
 julia = "~1"
 
 [extras]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["NLPModels", "Test"]
+test = ["ADNLPModels", "NLPModels", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,18 @@ uuid = "5049e819-d29b-5fba-b941-0eee7e64c1c6"
 version = "0.3.0"
 
 [deps]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
+ADNLPModels = "0.3"
 JuMP = "~0.19, ~0.20, ~0.21"
 julia = "~1"
 
 [extras]
+NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["NLPModels", "Test"]

--- a/src/ADNLPProblems/ADNLPProblems.jl
+++ b/src/ADNLPProblems/ADNLPProblems.jl
@@ -1,17 +1,23 @@
 module ADNLPProblems
 
-using ADNLPModels, LinearAlgebra
-import ..PureJuMP
+using Requires
 
 default_nvar = 100
+problems = []
 
-path = dirname(@__FILE__)
-files = filter(x -> x[(end - 2):end] == ".jl", readdir(path))
-for file in files
-  if file ≠ "ADNLPProblems.jl"
-    include(file)
-    name = split(file, ".")[1]
-    eval(Meta.parse("export $(name)"))
+@init begin
+  @require ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a" begin
+    using LinearAlgebra
+
+    path = dirname(@__FILE__)
+    files = filter(x -> x[(end - 2):end] == ".jl", readdir(path))
+    for file in files
+      if file ≠ "ADNLPProblems.jl"
+        include(file)
+        name = split(file, ".")[1]
+        push!(problems, name)
+      end
+    end
   end
 end
 

--- a/src/ADNLPProblems/ADNLPProblems.jl
+++ b/src/ADNLPProblems/ADNLPProblems.jl
@@ -1,0 +1,18 @@
+module ADNLPProblems
+
+using ADNLPModels, LinearAlgebra
+import ..PureJuMP
+
+default_nvar = 100
+
+path = dirname(@__FILE__)
+files = filter(x -> x[(end - 2):end] == ".jl", readdir(path))
+for file in files
+  if file ≠ "ADNLPProblems.jl"
+    include(file)
+    name = split(file, ".")[1]
+    eval(Meta.parse("export $(name)"))
+  end
+end
+
+end

--- a/src/ADNLPProblems/NZF1.jl
+++ b/src/ADNLPProblems/NZF1.jl
@@ -16,11 +16,10 @@ function NZF1(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
       (x[i + 6] + x[i + 7] - x[i + 8]^2 + x[i + 10])^2 +
       (log(1 + x[i + 10]^2) + x[i + 11] - 5 * x[i + 12] + 20)^2 +
       (x[i + 4] + x[i + 5] + x[i + 5] * x[i + 9] + 10 * x[i + 9] - 50)^2 for i = 1:l
-    )
-    +sum((x[i + 6] - x[i + 19])^2 for i = 1:(l - 1))
+    ) + sum((x[i + 6] - x[i + 19])^2 for i = 1:(l - 1))
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "NZF1_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "NZF1_autodiff"; kwargs...)
 end
 
 NZF1_meta = Dict(

--- a/src/ADNLPProblems/NZF1.jl
+++ b/src/ADNLPProblems/NZF1.jl
@@ -1,0 +1,53 @@
+function NZF1(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    nbis = max(1, div(n, 13))
+    n = 13 * nbis
+    l = div(n, 13)
+    return sum(
+      (3 * x[i] - 60 + T(0.1) * (x[i + 1] - x[i + 2])^2)^2 +
+      (
+        x[i + 1]^2 +
+        x[i + 2]^2 +
+        (x[i + 3]^2) * (1 + x[i + 3])^2 +
+        x[i + 6] +
+        x[i + 5] / (1 + x[i + 4]^2 + sin(x[i + 4] / 1000))
+      )^2 +
+      (x[i + 6] + x[i + 7] - x[i + 8]^2 + x[i + 10])^2 +
+      (log(1 + x[i + 10]^2) + x[i + 11] - 5 * x[i + 12] + 20)^2 +
+      (x[i + 4] + x[i + 5] + x[i + 5] * x[i + 9] + 10 * x[i + 9] - 50)^2 for i = 1:l
+    )
+    +sum((x[i + 6] - x[i + 19])^2 for i = 1:(l - 1))
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "NZF1_autodiff"; kwargs...)
+end
+
+NZF1_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "NZF1",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => UInt8(3),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_NZF1_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/arglina.jl
+++ b/src/ADNLPProblems/arglina.jl
@@ -1,0 +1,39 @@
+function arglina(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    m = 2 * n
+    return sum((x[i] - T(2 / m) * sum(x[j] for j = 1:n) - 1)^2 for i = 1:n) +
+           sum((-T(2 / m) * sum(x[j] for j = 1:n) - 1)^2 for i = (n + 1):m)
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "arglina"; kwargs...)
+end
+
+arglina_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "arglina",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_arglina_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/arglina.jl
+++ b/src/ADNLPProblems/arglina.jl
@@ -6,7 +6,7 @@ function arglina(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
            sum((-T(2 / m) * sum(x[j] for j = 1:n) - 1)^2 for i = (n + 1):m)
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "arglina"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "arglina"; kwargs...)
 end
 
 arglina_meta = Dict(

--- a/src/ADNLPProblems/arglinb.jl
+++ b/src/ADNLPProblems/arglinb.jl
@@ -1,0 +1,38 @@
+function arglinb(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    m = 2 * n
+    return sum((i * sum(j * x[j] for j = 1:n) - 1)^2 for i = 1:m)
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "arglinb_autodiff"; kwargs...)
+end
+
+arglinb_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "arglinb",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_arglinb_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/arglinb.jl
+++ b/src/ADNLPProblems/arglinb.jl
@@ -5,7 +5,7 @@ function arglinb(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     return sum((i * sum(j * x[j] for j = 1:n) - 1)^2 for i = 1:m)
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "arglinb_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "arglinb_autodiff"; kwargs...)
 end
 
 arglinb_meta = Dict(

--- a/src/ADNLPProblems/arglinc.jl
+++ b/src/ADNLPProblems/arglinc.jl
@@ -1,0 +1,38 @@
+function arglinc(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    m = 2 * n
+    return 2 + sum(((i - 1) * sum(j * x[j] for j = 2:(n - 1)) - 1)^2 for i = 2:(m - 1))
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "arglinc_autodiff"; kwargs...)
+end
+
+arglinc_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "arglinc",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_arglinc_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/arglinc.jl
+++ b/src/ADNLPProblems/arglinc.jl
@@ -5,7 +5,7 @@ function arglinc(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     return 2 + sum(((i - 1) * sum(j * x[j] for j = 2:(n - 1)) - 1)^2 for i = 2:(m - 1))
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "arglinc_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "arglinc_autodiff"; kwargs...)
 end
 
 arglinc_meta = Dict(

--- a/src/ADNLPProblems/arwhead.jl
+++ b/src/ADNLPProblems/arwhead.jl
@@ -1,0 +1,37 @@
+function arwhead(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return sum((x[i]^2 + x[n]^2)^2 - 4 * x[i] + 3 for i = 1:(n - 1))
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "arwhead_autodiff"; kwargs...)
+end
+
+arwhead_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "arwhead",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_arwhead_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/arwhead.jl
+++ b/src/ADNLPProblems/arwhead.jl
@@ -4,7 +4,7 @@ function arwhead(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     return sum((x[i]^2 + x[n]^2)^2 - 4 * x[i] + 3 for i = 1:(n - 1))
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "arwhead_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "arwhead_autodiff"; kwargs...)
 end
 
 arwhead_meta = Dict(

--- a/src/ADNLPProblems/bdqrtic.jl
+++ b/src/ADNLPProblems/bdqrtic.jl
@@ -8,7 +8,7 @@ function bdqrtic(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     )
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "bdqrtic_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "bdqrtic_autodiff"; kwargs...)
 end
 
 bdqrtic_meta = Dict(

--- a/src/ADNLPProblems/bdqrtic.jl
+++ b/src/ADNLPProblems/bdqrtic.jl
@@ -1,0 +1,41 @@
+function bdqrtic(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 5 || error("bdqrtic : n ≥ 5")
+  function f(x)
+    n = length(x)
+    return sum(
+      (3 - 4 * x[i])^2 + (x[i]^2 + 2 * x[i + 1]^2 + 3 * x[i + 2]^2 + 4 * x[i + 3]^2 + 5 * x[n]^2)^2
+      for i = 1:(n - 4)
+    )
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "bdqrtic_autodiff"; kwargs...)
+end
+
+bdqrtic_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "bdqrtic",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_bdqrtic_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/beale.jl
+++ b/src/ADNLPProblems/beale.jl
@@ -1,0 +1,39 @@
+function beale(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return (T(1.5) + x[1] * (1 - x[2]))^2 +
+           (T(2.25) + x[1] * (1 - x[2]^2))^2 +
+           (T(2.625) + x[1] * (1 - x[2]^3))^2
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "beale_autodiff"; kwargs...)
+end
+
+beale_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "beale",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_beale_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/beale.jl
+++ b/src/ADNLPProblems/beale.jl
@@ -6,7 +6,7 @@ function beale(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
            (T(2.625) + x[1] * (1 - x[2]^3))^2
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "beale_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "beale_autodiff"; kwargs...)
 end
 
 beale_meta = Dict(

--- a/src/ADNLPProblems/brownden.jl
+++ b/src/ADNLPProblems/brownden.jl
@@ -16,7 +16,7 @@ function brownden(;
     return s
   end
 
-  return ADNLPModel(f, x0, name = "brownden_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "brownden_autodiff"; kwargs...)
 end
 
 brownden_meta = Dict(

--- a/src/ADNLPProblems/brownden.jl
+++ b/src/ADNLPProblems/brownden.jl
@@ -1,0 +1,49 @@
+function brownden(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  x0 = T[25.0; 5.0; -5.0; -1.0]
+  f(x) = begin
+    s = zero(T)
+    for i = 1:20
+      s +=
+        (
+          (x[1] + x[2] * T(i) / 5 - exp(T(i) / 5))^2 +
+          (x[3] + x[4] * sin(T(i) / 5) - cos(T(i) / 5))^2
+        )^2
+    end
+    return s
+  end
+
+  return ADNLPModel(f, x0, name = "brownden_autodiff"; kwargs...)
+end
+
+brownden_meta = Dict(
+  :nvar => 4,
+  :variable_size => false,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 4,
+  :nnzh => 10,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "brownden",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_brownden_meta(; n::Integer = default_nvar) = (brownden_meta[:nvar], brownden_meta[:ncon])

--- a/src/ADNLPProblems/broydn7d.jl
+++ b/src/ADNLPProblems/broydn7d.jl
@@ -1,0 +1,47 @@
+function broydn7d(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n2 = max(1, div(n, 2))
+  n = 2 * n2  # number of variables adjusted to be even
+  function f(x)
+    n = length(x)
+    p = T(7 / 3)
+    return abs(1 - 2 * x[2] + (3 - x[1] / 2) * x[1])^p +
+           sum(abs(1 - x[i - 1] - 2 * x[i + 1] + (3 - x[i] / 2) * x[i])^p for i = 2:(n - 1)) +
+           abs(1 - x[n - 1] + (3 - x[n] / 2) * x[n])^p +
+           sum(abs(x[i] + x[i + n2])^p for i = 1:n2)
+  end
+  x0 = -ones(T, n)
+  return ADNLPModel(f, x0, name = "broydn7d_autodiff"; kwargs...)
+end
+
+broydn7d_meta = Dict(
+  :nvar => default_nvar, # n must be greater than 3
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "broydn7d",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => UInt8(2), # more?
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_broydn7d_meta(; n::Integer = default_nvar) = (2 * max(1, div(n, 2)), 0)

--- a/src/ADNLPProblems/broydn7d.jl
+++ b/src/ADNLPProblems/broydn7d.jl
@@ -14,7 +14,7 @@ function broydn7d(;
            sum(abs(x[i] + x[i + n2])^p for i = 1:n2)
   end
   x0 = -ones(T, n)
-  return ADNLPModel(f, x0, name = "broydn7d_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "broydn7d_autodiff"; kwargs...)
 end
 
 broydn7d_meta = Dict(

--- a/src/ADNLPProblems/brybnd.jl
+++ b/src/ADNLPProblems/brybnd.jl
@@ -11,7 +11,7 @@ function brybnd(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
     )
   end
   x0 = -ones(T, n)
-  return ADNLPModel(f, x0, name = "brybnd_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "brybnd_autodiff"; kwargs...)
 end
 
 brybnd_meta = Dict(

--- a/src/ADNLPProblems/brybnd.jl
+++ b/src/ADNLPProblems/brybnd.jl
@@ -1,0 +1,44 @@
+function brybnd(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    ml = 5
+    mu = 1
+    return sum(
+      (
+        x[i] * (2 + 5 * x[i]^2) + 1 -
+        sum(x[j] * (1 + x[j]) for j = max(1, i - ml):min(n, i + mu) if j != i)
+      )^2 for i = 1:n
+    )
+  end
+  x0 = -ones(T, n)
+  return ADNLPModel(f, x0, name = "brybnd_autodiff"; kwargs...)
+end
+
+brybnd_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "brybnd",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_brybnd_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/chainwoo.jl
+++ b/src/ADNLPProblems/chainwoo.jl
@@ -1,0 +1,49 @@
+function chainwoo(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n = 4 * max(1, div(n, 4))  # number of variables adjusted to be a multiple of 4
+  function f(x)
+    n = length(x)
+    return 1 + sum(
+      100 * (x[2 * i] - x[2 * i - 1]^2)^2 +
+      (1 - x[2 * i - 1])^2 +
+      90 * (x[2 * i + 2] - x[2 * i + 1]^2)^2 +
+      (1 - x[2 * i + 1])^2 +
+      10 * (x[2 * i] + x[2 * i + 2] - 2)^2 +
+      T(0.1) * (x[2 * i] - x[2 * i + 2])^2 for i = 1:(div(n, 2) - 1)
+    )
+  end
+  x0 = -2 * ones(T, n)
+  return ADNLPModel(f, x0, name = "chainwoo_autodiff"; kwargs...)
+end
+
+chainwoo_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "chainwoo",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_chainwoo_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/chainwoo.jl
+++ b/src/ADNLPProblems/chainwoo.jl
@@ -16,7 +16,7 @@ function chainwoo(;
     )
   end
   x0 = -2 * ones(T, n)
-  return ADNLPModel(f, x0, name = "chainwoo_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "chainwoo_autodiff"; kwargs...)
 end
 
 chainwoo_meta = Dict(

--- a/src/ADNLPProblems/chnrosnb_mod.jl
+++ b/src/ADNLPProblems/chnrosnb_mod.jl
@@ -1,0 +1,43 @@
+function chnrosnb_mod(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || ("chnrosnb : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return 16 * sum((x[i - 1] - x[i]^2)^2 * T(1.5 + sin(i))^2 for i = 2:n) +
+           sum((1 - x[i])^2 for i = 2:n)
+  end
+  x0 = -ones(T, n)
+  return ADNLPModel(f, x0, name = "chnrosnb_autodiff"; kwargs...)
+end
+
+chnrosnb_mod_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "chnrosnb_mod",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_chnrosnb_mod_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/chnrosnb_mod.jl
+++ b/src/ADNLPProblems/chnrosnb_mod.jl
@@ -10,7 +10,7 @@ function chnrosnb_mod(;
            sum((1 - x[i])^2 for i = 2:n)
   end
   x0 = -ones(T, n)
-  return ADNLPModel(f, x0, name = "chnrosnb_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "chnrosnb_autodiff"; kwargs...)
 end
 
 chnrosnb_mod_meta = Dict(

--- a/src/ADNLPProblems/cosine.jl
+++ b/src/ADNLPProblems/cosine.jl
@@ -1,0 +1,37 @@
+function cosine(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return sum(cos(x[i]^2 - x[i + 1] / 2) for i = 1:(n - 1))
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "cosine_autodiff"; kwargs...)
+end
+
+cosine_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "cosine",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_cosine_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/cosine.jl
+++ b/src/ADNLPProblems/cosine.jl
@@ -4,7 +4,7 @@ function cosine(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
     return sum(cos(x[i]^2 - x[i + 1] / 2) for i = 1:(n - 1))
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "cosine_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "cosine_autodiff"; kwargs...)
 end
 
 cosine_meta = Dict(

--- a/src/ADNLPProblems/cragglvy.jl
+++ b/src/ADNLPProblems/cragglvy.jl
@@ -15,7 +15,7 @@ function cragglvy(;
     )
   end
   x0 = 2 * ones(T, n)
-  return ADNLPModel(f, x0, name = "cragglvy_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "cragglvy_autodiff"; kwargs...)
 end
 
 cragglvy_meta = Dict(

--- a/src/ADNLPProblems/cragglvy.jl
+++ b/src/ADNLPProblems/cragglvy.jl
@@ -1,0 +1,48 @@
+function cragglvy(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || error("cragglvy : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return sum(
+      (exp(x[2 * i - 1]) - x[2 * i])^4 +
+      100 * (x[2 * i] - x[2 * i + 1])^6 +
+      (tan(x[2 * i + 1] - x[2 * i + 2]) + x[2 * i + 1] - x[2 * i + 2])^4 +
+      x[2 * i - 1]^8 +
+      (x[2 * i + 2] - 1)^2 for i = 1:(div(n, 2) - 1)
+    )
+  end
+  x0 = 2 * ones(T, n)
+  return ADNLPModel(f, x0, name = "cragglvy_autodiff"; kwargs...)
+end
+
+cragglvy_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "cragglvy",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => UInt8(1), # gradient not defined in [0, 0, pi/2, 0]
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_cragglvy_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/curly10.jl
+++ b/src/ADNLPProblems/curly10.jl
@@ -1,0 +1,44 @@
+function curly10(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("curly: number of variables must be ≥ 2")
+  n = max(2, n)
+  b = 10
+  function f(x)
+    n = length(x)
+    return sum(
+      (sum(x[j] for j = i:min(i + b, n))) *
+      ((sum(x[j] for j = i:min(i + b, n))) * ((sum(x[j] for j = i:min(i + b, n)))^2 - 20) - T(0.1))
+      for i = 1:n
+    )
+  end
+  x0 = T[1.0e-4 * i / (n + 1) for i = 1:n]
+  return ADNLPModel(f, x0, name = "curly10_autodiff"; kwargs...)
+end
+
+curly10_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "curly10",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_curly10_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/curly10.jl
+++ b/src/ADNLPProblems/curly10.jl
@@ -11,7 +11,7 @@ function curly10(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     )
   end
   x0 = T[1.0e-4 * i / (n + 1) for i = 1:n]
-  return ADNLPModel(f, x0, name = "curly10_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "curly10_autodiff"; kwargs...)
 end
 
 curly10_meta = Dict(

--- a/src/ADNLPProblems/curly20.jl
+++ b/src/ADNLPProblems/curly20.jl
@@ -11,7 +11,7 @@ function curly20(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     )
   end
   x0 = T[1.0e-4 * i / (n + 1) for i = 1:n]
-  return ADNLPModel(f, x0, name = "curly20_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "curly20_autodiff"; kwargs...)
 end
 
 curly20_meta = Dict(

--- a/src/ADNLPProblems/curly20.jl
+++ b/src/ADNLPProblems/curly20.jl
@@ -1,0 +1,44 @@
+function curly20(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("curly: number of variables must be ≥ 2")
+  n = max(2, n)
+  b = 20
+  function f(x)
+    n = length(x)
+    return sum(
+      (sum(x[j] for j = i:min(i + b, n))) *
+      ((sum(x[j] for j = i:min(i + b, n))) * ((sum(x[j] for j = i:min(i + b, n)))^2 - 20) - T(0.1))
+      for i = 1:n
+    )
+  end
+  x0 = T[1.0e-4 * i / (n + 1) for i = 1:n]
+  return ADNLPModel(f, x0, name = "curly20_autodiff"; kwargs...)
+end
+
+curly20_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "curly20",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_curly20_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/curly30.jl
+++ b/src/ADNLPProblems/curly30.jl
@@ -11,7 +11,7 @@ function curly30(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     )
   end
   x0 = T[1.0e-4 * i / (n + 1) for i = 1:n]
-  return ADNLPModel(f, x0, name = "curly30_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "curly30_autodiff"; kwargs...)
 end
 
 curly30_meta = Dict(

--- a/src/ADNLPProblems/curly30.jl
+++ b/src/ADNLPProblems/curly30.jl
@@ -1,0 +1,44 @@
+function curly30(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("curly: number of variables must be ≥ 2")
+  n = max(2, n)
+  b = 30
+  function f(x)
+    n = length(x)
+    return sum(
+      (sum(x[j] for j = i:min(i + b, n))) *
+      ((sum(x[j] for j = i:min(i + b, n))) * ((sum(x[j] for j = i:min(i + b, n)))^2 - 20) - T(0.1))
+      for i = 1:n
+    )
+  end
+  x0 = T[1.0e-4 * i / (n + 1) for i = 1:n]
+  return ADNLPModel(f, x0, name = "curly30_autodiff"; kwargs...)
+end
+
+curly30_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "curly30",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_curly30_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/dixon3dq.jl
+++ b/src/ADNLPProblems/dixon3dq.jl
@@ -1,0 +1,41 @@
+function dixon3dq(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  function f(x)
+    n = length(x)
+    return (x[1] - 1)^2 + (x[n] - 1)^2 + sum((x[i] - x[i + 1])^2 for i = 2:(n - 1))
+  end
+  x0 = -ones(T, n)
+  return ADNLPModel(f, x0, name = "dixon3dq_autodiff"; kwargs...)
+end
+
+dixon3dq_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "dixon3dq",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_dixon3dq_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/dixon3dq.jl
+++ b/src/ADNLPProblems/dixon3dq.jl
@@ -8,7 +8,7 @@ function dixon3dq(;
     return (x[1] - 1)^2 + (x[n] - 1)^2 + sum((x[i] - x[i + 1])^2 for i = 2:(n - 1))
   end
   x0 = -ones(T, n)
-  return ADNLPModel(f, x0, name = "dixon3dq_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "dixon3dq_autodiff"; kwargs...)
 end
 
 dixon3dq_meta = Dict(

--- a/src/ADNLPProblems/dqdrtic.jl
+++ b/src/ADNLPProblems/dqdrtic.jl
@@ -1,0 +1,37 @@
+function dqdrtic(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return sum(x[i]^2 + 100 * (x[i + 1]^2 + x[i + 2]^2) for i = 1:(n - 2))
+  end
+  x0 = 3 * ones(T, n)
+  return ADNLPModel(f, x0, name = "dqdrtic_autodiff"; kwargs...)
+end
+
+dqdrtic_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "dqdrtic",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_dqdrtic_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/dqdrtic.jl
+++ b/src/ADNLPProblems/dqdrtic.jl
@@ -4,7 +4,7 @@ function dqdrtic(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     return sum(x[i]^2 + 100 * (x[i + 1]^2 + x[i + 2]^2) for i = 1:(n - 2))
   end
   x0 = 3 * ones(T, n)
-  return ADNLPModel(f, x0, name = "dqdrtic_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "dqdrtic_autodiff"; kwargs...)
 end
 
 dqdrtic_meta = Dict(

--- a/src/ADNLPProblems/dqrtic.jl
+++ b/src/ADNLPProblems/dqrtic.jl
@@ -4,7 +4,7 @@ function dqrtic(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
     return sum((x[i] - i)^4 for i = 1:n)
   end
   x0 = 2 * ones(T, n)
-  return ADNLPModel(f, x0, name = "dqrtic_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "dqrtic_autodiff"; kwargs...)
 end
 
 dqrtic_meta = Dict(

--- a/src/ADNLPProblems/dqrtic.jl
+++ b/src/ADNLPProblems/dqrtic.jl
@@ -1,0 +1,37 @@
+function dqrtic(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return sum((x[i] - i)^4 for i = 1:n)
+  end
+  x0 = 2 * ones(T, n)
+  return ADNLPModel(f, x0, name = "dqrtic_autodiff"; kwargs...)
+end
+
+dqrtic_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "dqrtic",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_dqrtic_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/edensch.jl
+++ b/src/ADNLPProblems/edensch.jl
@@ -6,7 +6,7 @@ function edensch(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     )
   end
   x0 = zeros(T, n)
-  return ADNLPModel(f, x0, name = "edensch_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "edensch_autodiff"; kwargs...)
 end
 
 edensch_meta = Dict(

--- a/src/ADNLPProblems/edensch.jl
+++ b/src/ADNLPProblems/edensch.jl
@@ -1,0 +1,39 @@
+function edensch(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return 16 + sum(
+      (x[i] - 2)^4 + (x[i] * x[i + 1] - 2 * x[i + 1])^2 + (x[i + 1] + 1)^2 for i = 1:(n - 1)
+    )
+  end
+  x0 = zeros(T, n)
+  return ADNLPModel(f, x0, name = "edensch_autodiff"; kwargs...)
+end
+
+edensch_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "edensch",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_edensch_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/eg2.jl
+++ b/src/ADNLPProblems/eg2.jl
@@ -1,0 +1,37 @@
+function eg2(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    sum(sin(x[1] + x[i]^2 - 1) for i = 1:(n - 1)) + sin(x[n]^2) / 2
+  end
+  x0 = zeros(T, n)
+  return ADNLPModel(f, x0, name = "eg2_autodiff"; kwargs...)
+end
+
+eg2_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "eg2",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_eg2_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/eg2.jl
+++ b/src/ADNLPProblems/eg2.jl
@@ -4,7 +4,7 @@ function eg2(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) wh
     sum(sin(x[1] + x[i]^2 - 1) for i = 1:(n - 1)) + sin(x[n]^2) / 2
   end
   x0 = zeros(T, n)
-  return ADNLPModel(f, x0, name = "eg2_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "eg2_autodiff"; kwargs...)
 end
 
 eg2_meta = Dict(

--- a/src/ADNLPProblems/engval1.jl
+++ b/src/ADNLPProblems/engval1.jl
@@ -1,0 +1,38 @@
+function engval1(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 2 || error("engval : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return sum((x[i]^2 + x[i + 1]^2)^2 - 4 * x[i] + 3 for i = 1:(n - 1))
+  end
+  x0 = 2 * ones(T, n)
+  return ADNLPModel(f, x0, name = "engval1_autodiff"; kwargs...)
+end
+
+engval1_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "engval1",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_engval1_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/engval1.jl
+++ b/src/ADNLPProblems/engval1.jl
@@ -5,7 +5,7 @@ function engval1(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     return sum((x[i]^2 + x[i + 1]^2)^2 - 4 * x[i] + 3 for i = 1:(n - 1))
   end
   x0 = 2 * ones(T, n)
-  return ADNLPModel(f, x0, name = "engval1_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "engval1_autodiff"; kwargs...)
 end
 
 engval1_meta = Dict(

--- a/src/ADNLPProblems/errinros_mod.jl
+++ b/src/ADNLPProblems/errinros_mod.jl
@@ -10,7 +10,7 @@ function errinros_mod(;
            sum((1 - x[i])^2 for i = 2:n)
   end
   x0 = -ones(T, n)
-  return ADNLPModel(f, x0, name = "errinros_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "errinros_autodiff"; kwargs...)
 end
 
 errinros_mod_meta = Dict(

--- a/src/ADNLPProblems/errinros_mod.jl
+++ b/src/ADNLPProblems/errinros_mod.jl
@@ -1,0 +1,43 @@
+function errinros_mod(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || error("errinros : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return sum((x[i - 1] - 16 * x[i]^2 * T(1.5 + sin(i))^2)^2 for i = 2:n) +
+           sum((1 - x[i])^2 for i = 2:n)
+  end
+  x0 = -ones(T, n)
+  return ADNLPModel(f, x0, name = "errinros_autodiff"; kwargs...)
+end
+
+errinros_mod_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "errinros_mod",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_errinros_mod_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/extrosnb.jl
+++ b/src/ADNLPProblems/extrosnb.jl
@@ -8,7 +8,7 @@ function extrosnb(;
     return 100 * sum((x[i] - x[i - 1]^2)^2 for i = 2:n) + (1 - x[1])^2
   end
   x0 = -ones(T, n)
-  return ADNLPModel(f, x0, name = "extrosnb_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "extrosnb_autodiff"; kwargs...)
 end
 
 extrosnb_meta = Dict(

--- a/src/ADNLPProblems/extrosnb.jl
+++ b/src/ADNLPProblems/extrosnb.jl
@@ -1,0 +1,41 @@
+function extrosnb(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  function f(x)
+    n = length(x)
+    return 100 * sum((x[i] - x[i - 1]^2)^2 for i = 2:n) + (1 - x[1])^2
+  end
+  x0 = -ones(T, n)
+  return ADNLPModel(f, x0, name = "extrosnb_autodiff"; kwargs...)
+end
+
+extrosnb_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "extrosnb",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_extrosnb_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/fletcbv2.jl
+++ b/src/ADNLPProblems/fletcbv2.jl
@@ -1,0 +1,44 @@
+function fletcbv2(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || error("fletcbv2 : n ≥ 2")
+  function f(x)
+    n = length(x)
+    h = T(1 / (n + 1))
+    return T(0.5) * (x[1]^2 + sum((x[i] - x[i + 1])^2 for i = 1:(n - 1)) + x[n]^2) -
+           h^2 * sum(2 * x[i] + cos(x[i]) for i = 1:n) - x[n]
+  end
+  x0 = T.([(i / (n + 1)) for i = 1:n])
+  return ADNLPModel(f, x0, name = "fletcbv2_autodiff"; kwargs...)
+end
+
+fletcbv2_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "fletcbv2",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_fletcbv2_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/fletcbv2.jl
+++ b/src/ADNLPProblems/fletcbv2.jl
@@ -11,7 +11,7 @@ function fletcbv2(;
            h^2 * sum(2 * x[i] + cos(x[i]) for i = 1:n) - x[n]
   end
   x0 = T.([(i / (n + 1)) for i = 1:n])
-  return ADNLPModel(f, x0, name = "fletcbv2_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "fletcbv2_autodiff"; kwargs...)
 end
 
 fletcbv2_meta = Dict(

--- a/src/ADNLPProblems/fletcbv3_mod.jl
+++ b/src/ADNLPProblems/fletcbv3_mod.jl
@@ -12,7 +12,7 @@ function fletcbv3_mod(;
            p * sum(100 * (1 + (2 / h^2)) * sin(x[i] / 100) + (1 / h^2) * cos(x[i]) for i = 1:n)
   end
   x0 = T.([(i / (n + 1)) for i = 1:n])
-  return ADNLPModel(f, x0, name = "fletcbv3_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "fletcbv3_autodiff"; kwargs...)
 end
 
 fletcbv3_mod_meta = Dict(

--- a/src/ADNLPProblems/fletcbv3_mod.jl
+++ b/src/ADNLPProblems/fletcbv3_mod.jl
@@ -1,0 +1,45 @@
+function fletcbv3_mod(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || error("fletcbv3 : n ≥ 2")
+  function f(x)
+    n = length(x)
+    p = T(10.0^(-8))
+    h = T(1 / (n + 1))
+    return (p / 2) * (x[1]^2 + sum((x[i] - x[i + 1])^2 for i = 1:(n - 1)) + x[n]^2) -
+           p * sum(100 * (1 + (2 / h^2)) * sin(x[i] / 100) + (1 / h^2) * cos(x[i]) for i = 1:n)
+  end
+  x0 = T.([(i / (n + 1)) for i = 1:n])
+  return ADNLPModel(f, x0, name = "fletcbv3_autodiff"; kwargs...)
+end
+
+fletcbv3_mod_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "fletcbv3_mod",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_fletcbv3_mod_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/fletchcr.jl
+++ b/src/ADNLPProblems/fletchcr.jl
@@ -8,7 +8,7 @@ function fletchcr(;
     return 100 * sum((x[i + 1] - x[i] + 1 - x[i]^2)^2 for i = 1:(n - 1))
   end
   x0 = zeros(T, n)
-  return ADNLPModel(f, x0, name = "fletchcr_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "fletchcr_autodiff"; kwargs...)
 end
 
 fletchcr_meta = Dict(

--- a/src/ADNLPProblems/fletchcr.jl
+++ b/src/ADNLPProblems/fletchcr.jl
@@ -1,0 +1,41 @@
+function fletchcr(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  function f(x)
+    n = length(x)
+    return 100 * sum((x[i + 1] - x[i] + 1 - x[i]^2)^2 for i = 1:(n - 1))
+  end
+  x0 = zeros(T, n)
+  return ADNLPModel(f, x0, name = "fletchcr_autodiff"; kwargs...)
+end
+
+fletchcr_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "fletchcr",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_fletchcr_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/freuroth.jl
+++ b/src/ADNLPProblems/freuroth.jl
@@ -12,7 +12,7 @@ function freuroth(;
   x0 = zeros(T, n)
   x0[1] = one(T) / 2
   x0[2] = -2 * one(T)
-  return ADNLPModel(f, x0, name = "freuroth_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "freuroth_autodiff"; kwargs...)
 end
 
 freuroth_meta = Dict(

--- a/src/ADNLPProblems/freuroth.jl
+++ b/src/ADNLPProblems/freuroth.jl
@@ -1,0 +1,45 @@
+function freuroth(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  function f(x)
+    n = length(x)
+    return sum(((5 - x[i + 1]) * x[i + 1]^2 + x[i] - 2 * x[i + 1] - 13)^2 for i = 1:(n - 1)) +
+           sum(((1 + x[i + 1]) * x[i + 1]^2 + x[i] - 14 * x[i + 1] - 29)^2 for i = 1:(n - 1))
+  end
+
+  x0 = zeros(T, n)
+  x0[1] = one(T) / 2
+  x0[2] = -2 * one(T)
+  return ADNLPModel(f, x0, name = "freuroth_autodiff"; kwargs...)
+end
+
+freuroth_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "freuroth",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_freuroth_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/genhumps.jl
+++ b/src/ADNLPProblems/genhumps.jl
@@ -1,0 +1,46 @@
+function genhumps(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  function f(x)
+    n = length(x)
+    ζ = 20
+    return sum(
+      (sin(ζ * x[i])^2 * sin(ζ * x[i + 1])^2 + (x[i]^2 + x[i + 1]^2) / ζ) for i = 1:(n - 1)
+    )
+  end
+
+  x0 = -T(506.2) * ones(T, n)
+  x0[1] = -506
+  return ADNLPModel(f, x0, name = "genhumps_autodiff"; kwargs...)
+end
+
+genhumps_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "genhumps",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_genhumps_meta(; n::Int = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/genhumps.jl
+++ b/src/ADNLPProblems/genhumps.jl
@@ -13,7 +13,7 @@ function genhumps(;
 
   x0 = -T(506.2) * ones(T, n)
   x0[1] = -506
-  return ADNLPModel(f, x0, name = "genhumps_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "genhumps_autodiff"; kwargs...)
 end
 
 genhumps_meta = Dict(

--- a/src/ADNLPProblems/genrose.jl
+++ b/src/ADNLPProblems/genrose.jl
@@ -6,7 +6,7 @@ function genrose(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
            sum((x[i] - 1)^2 for i = 1:(n - 1))
   end
   x0 = T.([i / (n + 1) for i = 1:n])
-  return ADNLPModel(f, x0, name = "genrose_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "genrose_autodiff"; kwargs...)
 end
 
 genrose_meta = Dict(

--- a/src/ADNLPProblems/genrose.jl
+++ b/src/ADNLPProblems/genrose.jl
@@ -1,0 +1,39 @@
+function genrose(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return 1 +
+           100 * sum((x[i + 1] - x[i]^2)^2 for i = 1:(n - 1)) +
+           sum((x[i] - 1)^2 for i = 1:(n - 1))
+  end
+  x0 = T.([i / (n + 1) for i = 1:n])
+  return ADNLPModel(f, x0, name = "genrose_autodiff"; kwargs...)
+end
+
+genrose_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "genrose",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_genrose_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/genrose_nash.jl
+++ b/src/ADNLPProblems/genrose_nash.jl
@@ -9,7 +9,7 @@ function genrose_nash(;
     return 1 + 100 * sum((x[i] - x[i - 1]^2)^2 for i = 2:n) + sum((1 - x[i])^2 for i = 2:n)
   end
   x0 = T.([(i / (n + 1)) for i = 1:n])
-  return ADNLPModel(f, x0, name = "genrose_nash_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "genrose_nash_autodiff"; kwargs...)
 end
 
 genrose_nash_meta = Dict(

--- a/src/ADNLPProblems/genrose_nash.jl
+++ b/src/ADNLPProblems/genrose_nash.jl
@@ -1,0 +1,42 @@
+function genrose_nash(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || error("genrose_nash : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return 1 + 100 * sum((x[i] - x[i - 1]^2)^2 for i = 2:n) + sum((1 - x[i])^2 for i = 2:n)
+  end
+  x0 = T.([(i / (n + 1)) for i = 1:n])
+  return ADNLPModel(f, x0, name = "genrose_nash_autodiff"; kwargs...)
+end
+
+genrose_nash_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "genrose_nash",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_genrose_nash_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/hs10.jl
+++ b/src/ADNLPProblems/hs10.jl
@@ -1,0 +1,38 @@
+function hs10(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  x0 = T[-10; 10]
+  f(x) = x[1] - x[2]
+  c(x) = T[-3 * x[1]^2 + 2 * x[1] * x[2] - x[2]^2 + 1]
+  lcon = T[0.0]
+  ucon = T[Inf]
+
+  return ADNLPModel(f, x0, c, lcon, ucon, name = "hs10_autodiff"; kwargs...)
+end
+
+hs10_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 1,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 2,
+  :minimize => true,
+  :name => "hs10",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :linear,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => true,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs10_meta(; n::Integer = default_nvar) = (hs10_meta[:nvar], hs10_meta[:ncon])

--- a/src/ADNLPProblems/hs10.jl
+++ b/src/ADNLPProblems/hs10.jl
@@ -5,7 +5,7 @@ function hs10(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   lcon = T[0.0]
   ucon = T[Inf]
 
-  return ADNLPModel(f, x0, c, lcon, ucon, name = "hs10_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs10_autodiff"; kwargs...)
 end
 
 hs10_meta = Dict(

--- a/src/ADNLPProblems/hs11.jl
+++ b/src/ADNLPProblems/hs11.jl
@@ -1,0 +1,38 @@
+function hs11(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  x0 = T[4.9; 0.1]
+  f(x) = (x[1] - 5)^2 + x[2]^2 - 25
+  c(x) = T[-x[1]^2 + x[2]]
+  lcon = T[-Inf]
+  ucon = T[0.0]
+
+  return ADNLPModel(f, x0, c, lcon, ucon, name = "hs11_autodiff"; kwargs...)
+end
+
+hs11_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 1,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 2,
+  :minimize => true,
+  :name => "hs11",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => true,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs11_meta(; n::Integer = default_nvar) = (hs11_meta[:nvar], hs11_meta[:ncon])

--- a/src/ADNLPProblems/hs11.jl
+++ b/src/ADNLPProblems/hs11.jl
@@ -5,7 +5,7 @@ function hs11(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   lcon = T[-Inf]
   ucon = T[0.0]
 
-  return ADNLPModel(f, x0, c, lcon, ucon, name = "hs11_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs11_autodiff"; kwargs...)
 end
 
 hs11_meta = Dict(

--- a/src/ADNLPProblems/hs14.jl
+++ b/src/ADNLPProblems/hs14.jl
@@ -5,7 +5,7 @@ function hs14(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   lcon = T[0; 0]
   ucon = T[0; Inf]
 
-  return ADNLPModel(f, x0, c, lcon, ucon, name = "hs14_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs14_autodiff"; kwargs...)
 end
 
 hs14_meta = Dict(

--- a/src/ADNLPProblems/hs14.jl
+++ b/src/ADNLPProblems/hs14.jl
@@ -1,0 +1,38 @@
+function hs14(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  x0 = T[2; 2]
+  f(x) = (x[1] - 2)^2 + (x[2] - 1)^2
+  c(x) = T[x[1] - 2 * x[2] + 1; -x[1]^2 / 4 - x[2]^2 + 1]
+  lcon = T[0; 0]
+  ucon = T[0; Inf]
+
+  return ADNLPModel(f, x0, c, lcon, ucon, name = "hs14_autodiff"; kwargs...)
+end
+
+hs14_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 4,
+  :minimize => true,
+  :name => "hs14",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs14_meta(; n::Integer = default_nvar) = (hs14_meta[:nvar], hs14_meta[:ncon])

--- a/src/ADNLPProblems/hs26.jl
+++ b/src/ADNLPProblems/hs26.jl
@@ -1,5 +1,5 @@
 function hs26(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - x[2])^2 + (x[2] - x[3])^4,
     T[-2.6, 2.0, 2.0],
     x -> [(1 + x[2]^2) * x[1] + x[3]^4 - 3],

--- a/src/ADNLPProblems/hs26.jl
+++ b/src/ADNLPProblems/hs26.jl
@@ -1,0 +1,40 @@
+function hs26(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - x[2])^2 + (x[2] - x[3])^4,
+    T[-2.6, 2.0, 2.0],
+    x -> [(1 + x[2]^2) * x[1] + x[3]^4 - 3],
+    zeros(T, 1),
+    zeros(T, 1),
+    name = "hs26_autodiff";
+    kwargs...,
+  )
+end
+
+hs26_meta = Dict(
+  :nvar => 3,
+  :variable_size => false,
+  :ncon => 1,
+  :variable_con_size => false,
+  :nnzo => 3,
+  :nnzh => 6,
+  :nnzj => 3,
+  :minimize => true,
+  :name => "hs26",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :sum_of_squares,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs26_meta(; n::Integer = default_nvar) = (hs26_meta[:nvar], hs26_meta[:ncon])

--- a/src/ADNLPProblems/hs27.jl
+++ b/src/ADNLPProblems/hs27.jl
@@ -1,0 +1,40 @@
+function hs27(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> T(0.01) * (x[1] - 1)^2 + (x[2] - x[1]^2)^2,
+    2ones(T, 3),
+    x -> [x[1] + x[3]^2 + 1],
+    zeros(T, 1),
+    zeros(T, 1),
+    name = "hs27_autodiff";
+    kwargs...,
+  )
+end
+
+hs27_meta = Dict(
+  :nvar => 3,
+  :variable_size => false,
+  :ncon => 1,
+  :variable_con_size => false,
+  :nnzo => 3,
+  :nnzh => 6,
+  :nnzj => 3,
+  :minimize => true,
+  :name => "hs27",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :sum_of_squares,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs27_meta(; n::Integer = default_nvar) = (hs27_meta[:nvar], hs27_meta[:ncon])

--- a/src/ADNLPProblems/hs27.jl
+++ b/src/ADNLPProblems/hs27.jl
@@ -1,5 +1,5 @@
 function hs27(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> T(0.01) * (x[1] - 1)^2 + (x[2] - x[1]^2)^2,
     2ones(T, 3),
     x -> [x[1] + x[3]^2 + 1],

--- a/src/ADNLPProblems/hs28.jl
+++ b/src/ADNLPProblems/hs28.jl
@@ -1,0 +1,40 @@
+function hs28(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] + x[2])^2 + (x[2] + x[3])^2,
+    T[-4.0, 1.0, 1.0],
+    x -> [x[1] + 2 * x[2] + 3 * x[3] - 1],
+    zeros(T, 1),
+    zeros(T, 1),
+    name = "hs28_autodiff";
+    kwargs...,
+  )
+end
+
+hs28_meta = Dict(
+  :nvar => 3,
+  :variable_size => false,
+  :ncon => 1,
+  :variable_con_size => false,
+  :nnzo => 3,
+  :nnzh => 6,
+  :nnzj => 3,
+  :minimize => true,
+  :name => "hs28",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs28_meta(; n::Integer = default_nvar) = (hs28_meta[:nvar], hs28_meta[:ncon])

--- a/src/ADNLPProblems/hs28.jl
+++ b/src/ADNLPProblems/hs28.jl
@@ -1,5 +1,5 @@
 function hs28(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] + x[2])^2 + (x[2] + x[3])^2,
     T[-4.0, 1.0, 1.0],
     x -> [x[1] + 2 * x[2] + 3 * x[3] - 1],

--- a/src/ADNLPProblems/hs39.jl
+++ b/src/ADNLPProblems/hs39.jl
@@ -1,0 +1,40 @@
+function hs39(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> -x[1],
+    2ones(T, 4),
+    x -> [x[2] - x[1]^3 - x[3]^2; x[1]^2 - x[2] - x[4]^2],
+    zeros(T, 2),
+    zeros(T, 2),
+    name = "hs39_autodiff";
+    kwargs...,
+  )
+end
+
+hs39_meta = Dict(
+  :nvar => 4,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 4,
+  :nnzh => 10,
+  :nnzj => 8,
+  :minimize => true,
+  :name => "hs39",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :linear,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs39_meta(; n::Integer = default_nvar) = (hs39_meta[:nvar], hs39_meta[:ncon])

--- a/src/ADNLPProblems/hs39.jl
+++ b/src/ADNLPProblems/hs39.jl
@@ -1,5 +1,5 @@
 function hs39(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> -x[1],
     2ones(T, 4),
     x -> [x[2] - x[1]^3 - x[3]^2; x[1]^2 - x[2] - x[4]^2],

--- a/src/ADNLPProblems/hs40.jl
+++ b/src/ADNLPProblems/hs40.jl
@@ -1,5 +1,5 @@
 function hs40(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> -x[1] * x[2] * x[3] * x[4],
     T(0.8) * ones(T, 4),
     x -> [x[1]^3 + x[2]^2 - 1; x[4] * x[1]^2 - x[3]; x[4]^2 - x[2]],

--- a/src/ADNLPProblems/hs40.jl
+++ b/src/ADNLPProblems/hs40.jl
@@ -1,0 +1,40 @@
+function hs40(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> -x[1] * x[2] * x[3] * x[4],
+    T(0.8) * ones(T, 4),
+    x -> [x[1]^3 + x[2]^2 - 1; x[4] * x[1]^2 - x[3]; x[4]^2 - x[2]],
+    zeros(T, 3),
+    zeros(T, 3),
+    name = "hs40_autodiff";
+    kwargs...,
+  )
+end
+
+hs40_meta = Dict(
+  :nvar => 4,
+  :variable_size => false,
+  :ncon => 3,
+  :variable_con_size => false,
+  :nnzo => 4,
+  :nnzh => 10,
+  :nnzj => 12,
+  :minimize => true,
+  :name => "hs40",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :other,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs40_meta(; n::Integer = default_nvar) = (hs40_meta[:nvar], hs40_meta[:ncon])

--- a/src/ADNLPProblems/hs42.jl
+++ b/src/ADNLPProblems/hs42.jl
@@ -1,5 +1,5 @@
 function hs42(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - 1)^2 + (x[2] - 2)^2 + (x[3] - 3)^2 + (x[4] - 4)^2,
     ones(T, 4),
     x -> [x[3]^2 + x[4]^2 - 2; x[1] - 2],

--- a/src/ADNLPProblems/hs42.jl
+++ b/src/ADNLPProblems/hs42.jl
@@ -1,0 +1,40 @@
+function hs42(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - 1)^2 + (x[2] - 2)^2 + (x[3] - 3)^2 + (x[4] - 4)^2,
+    ones(T, 4),
+    x -> [x[3]^2 + x[4]^2 - 2; x[1] - 2],
+    zeros(T, 2),
+    zeros(T, 2),
+    name = "hs42_autodiff";
+    kwargs...,
+  )
+end
+
+hs42_meta = Dict(
+  :nvar => 4,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 4,
+  :nnzh => 10,
+  :nnzj => 8,
+  :minimize => true,
+  :name => "hs42",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs42_meta(; n::Integer = default_nvar) = (hs42_meta[:nvar], hs42_meta[:ncon])

--- a/src/ADNLPProblems/hs46.jl
+++ b/src/ADNLPProblems/hs46.jl
@@ -1,0 +1,40 @@
+function hs46(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - x[2])^2 + (x[3] - 1)^2 + (x[4] - 1)^4 + (x[5] - 1)^6,
+    T[sqrt(2) / 2, 1.75, 0.5, 2, 2],
+    x -> [(x[1]^2) * x[4] + sin(x[4] - x[5]) - 1; x[2] + (x[3]^4) * (x[4]^2) - 2],
+    zeros(T, 2),
+    zeros(T, 2),
+    name = "hs46_autodiff";
+    kwargs...,
+  )
+end
+
+hs46_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 10,
+  :minimize => true,
+  :name => "hs46",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :sum_of_squares,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs46_meta(; n::Integer = default_nvar) = (hs46_meta[:nvar], hs46_meta[:ncon])

--- a/src/ADNLPProblems/hs46.jl
+++ b/src/ADNLPProblems/hs46.jl
@@ -1,5 +1,5 @@
 function hs46(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - x[2])^2 + (x[3] - 1)^2 + (x[4] - 1)^4 + (x[5] - 1)^6,
     T[sqrt(2) / 2, 1.75, 0.5, 2, 2],
     x -> [(x[1]^2) * x[4] + sin(x[4] - x[5]) - 1; x[2] + (x[3]^4) * (x[4]^2) - 2],

--- a/src/ADNLPProblems/hs47.jl
+++ b/src/ADNLPProblems/hs47.jl
@@ -1,5 +1,5 @@
 function hs47(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - x[2])^2 + (x[2] - x[3])^3 + (x[3] - x[4])^4 + (x[4] - x[5])^4,
     T[35, -31, 11, 5, -5],
     x -> [x[1] + x[2]^2 + x[3]^3 - 3; x[2] - x[3]^2 + x[4] - 1; x[1] * x[5] - 1],

--- a/src/ADNLPProblems/hs47.jl
+++ b/src/ADNLPProblems/hs47.jl
@@ -1,0 +1,40 @@
+function hs47(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - x[2])^2 + (x[2] - x[3])^3 + (x[3] - x[4])^4 + (x[4] - x[5])^4,
+    T[35, -31, 11, 5, -5],
+    x -> [x[1] + x[2]^2 + x[3]^3 - 3; x[2] - x[3]^2 + x[4] - 1; x[1] * x[5] - 1],
+    zeros(T, 3),
+    zeros(T, 3),
+    name = "hs47_autodiff";
+    kwargs...,
+  )
+end
+
+hs47_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 3,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 15,
+  :minimize => true,
+  :name => "hs47",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :other,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs47_meta(; n::Integer = default_nvar) = (hs47_meta[:nvar], hs47_meta[:ncon])

--- a/src/ADNLPProblems/hs48.jl
+++ b/src/ADNLPProblems/hs48.jl
@@ -1,5 +1,5 @@
 function hs48(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - 1)^2 + (x[2] - x[3])^2 + (x[4] - x[5])^2,
     T[3, 5, -3, 2, -2],
     x -> [x[1] + x[2] + x[3] + x[4] + x[5] - 5; x[3] - 2 * (x[4] + x[5]) + 3],

--- a/src/ADNLPProblems/hs48.jl
+++ b/src/ADNLPProblems/hs48.jl
@@ -1,0 +1,40 @@
+function hs48(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - 1)^2 + (x[2] - x[3])^2 + (x[4] - x[5])^2,
+    T[3, 5, -3, 2, -2],
+    x -> [x[1] + x[2] + x[3] + x[4] + x[5] - 5; x[3] - 2 * (x[4] + x[5]) + 3],
+    zeros(T, 2),
+    zeros(T, 2),
+    name = "hs48_autodiff";
+    kwargs...,
+  )
+end
+
+hs48_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 10,
+  :minimize => true,
+  :name => "hs48",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs48_meta(; n::Integer = default_nvar) = (hs48_meta[:nvar], hs48_meta[:ncon])

--- a/src/ADNLPProblems/hs49.jl
+++ b/src/ADNLPProblems/hs49.jl
@@ -1,0 +1,40 @@
+function hs49(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - x[2])^2 + (x[3] - 1)^2 + (x[4] - 1)^4 + (x[5] - 1)^6,
+    T[10, 7, 2, -3, 0.8],
+    x -> [x[1] + x[2] + x[3] + 4 * x[4] - 7; x[3] + 5 * x[5] - 6],
+    zeros(T, 2),
+    zeros(T, 2),
+    name = "hs49_autodiff";
+    kwargs...,
+  )
+end
+
+hs49_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 10,
+  :minimize => true,
+  :name => "hs49",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :sum_of_squares,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs49_meta(; n::Integer = default_nvar) = (hs49_meta[:nvar], hs49_meta[:ncon])

--- a/src/ADNLPProblems/hs49.jl
+++ b/src/ADNLPProblems/hs49.jl
@@ -1,5 +1,5 @@
 function hs49(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - x[2])^2 + (x[3] - 1)^2 + (x[4] - 1)^4 + (x[5] - 1)^6,
     T[10, 7, 2, -3, 0.8],
     x -> [x[1] + x[2] + x[3] + 4 * x[4] - 7; x[3] + 5 * x[5] - 6],

--- a/src/ADNLPProblems/hs5.jl
+++ b/src/ADNLPProblems/hs5.jl
@@ -1,0 +1,37 @@
+function hs5(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  x0 = zeros(T, 2)
+  f(x) = sin(x[1] + x[2]) + (x[1] - x[2])^2 - 3x[1] / 2 + 5x[2] / 2 + 1
+  l = T[-1.5; -3.0]
+  u = T[4.0; 3.0]
+
+  return ADNLPModel(f, x0, l, u, name = "hs5_autodiff"; kwargs...)
+end
+
+hs5_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "hs5",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => true,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs5_meta(; n::Integer = default_nvar) = (hs5_meta[:nvar], hs5_meta[:ncon])

--- a/src/ADNLPProblems/hs5.jl
+++ b/src/ADNLPProblems/hs5.jl
@@ -4,7 +4,7 @@ function hs5(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) wh
   l = T[-1.5; -3.0]
   u = T[4.0; 3.0]
 
-  return ADNLPModel(f, x0, l, u, name = "hs5_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, l, u, name = "hs5_autodiff"; kwargs...)
 end
 
 hs5_meta = Dict(

--- a/src/ADNLPProblems/hs50.jl
+++ b/src/ADNLPProblems/hs50.jl
@@ -1,0 +1,44 @@
+function hs50(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - x[2])^2 + (x[2] - x[3])^2 + (x[3] - x[4])^4 + (x[4] - x[5])^2,
+    T[35, -31, 11, 5, -5],
+    x -> [
+      x[1] + 2 * x[2] + 3 * x[3] - 6
+      x[2] + 2 * x[3] + 3 * x[4] - 6
+      x[3] + 2 * x[4] + 3 * x[5] - 6
+    ],
+    zeros(T, 3),
+    zeros(T, 3),
+    name = "hs50_autodiff";
+    kwargs...,
+  )
+end
+
+hs50_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 3,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 15,
+  :minimize => true,
+  :name => "hs50",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs50_meta(; n::Integer = default_nvar) = (hs50_meta[:nvar], hs50_meta[:ncon])

--- a/src/ADNLPProblems/hs50.jl
+++ b/src/ADNLPProblems/hs50.jl
@@ -1,5 +1,5 @@
 function hs50(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - x[2])^2 + (x[2] - x[3])^2 + (x[3] - x[4])^4 + (x[4] - x[5])^2,
     T[35, -31, 11, 5, -5],
     x -> [

--- a/src/ADNLPProblems/hs51.jl
+++ b/src/ADNLPProblems/hs51.jl
@@ -1,5 +1,5 @@
 function hs51(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - x[2])^2 + (x[2] + x[3] - 2)^2 + (x[4] - 1)^2 + (x[5] - 1)^2,
     T[2.5, 0.5, 2.0, -1.0, 0.5],
     x -> [x[1] + 3 * x[2] - 4; x[3] + x[4] - 2 * x[5]; x[2] - x[5]],

--- a/src/ADNLPProblems/hs51.jl
+++ b/src/ADNLPProblems/hs51.jl
@@ -1,0 +1,40 @@
+function hs51(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - x[2])^2 + (x[2] + x[3] - 2)^2 + (x[4] - 1)^2 + (x[5] - 1)^2,
+    T[2.5, 0.5, 2.0, -1.0, 0.5],
+    x -> [x[1] + 3 * x[2] - 4; x[3] + x[4] - 2 * x[5]; x[2] - x[5]],
+    zeros(T, 3),
+    zeros(T, 3),
+    name = "hs51_autodiff";
+    kwargs...,
+  )
+end
+
+hs51_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 3,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 15,
+  :minimize => true,
+  :name => "hs51",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs51_meta(; n::Integer = default_nvar) = (hs51_meta[:nvar], hs51_meta[:ncon])

--- a/src/ADNLPProblems/hs52.jl
+++ b/src/ADNLPProblems/hs52.jl
@@ -1,5 +1,5 @@
 function hs52(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (4 * x[1] - x[2])^2 + (x[2] + x[3] - 2)^2 + (x[4] - 1)^2 + (x[5] - 1)^2,
     2 * ones(T, 5),
     x -> [x[1] + 3 * x[2]; x[3] + x[4] - 2 * x[5]; x[2] - x[5]],

--- a/src/ADNLPProblems/hs52.jl
+++ b/src/ADNLPProblems/hs52.jl
@@ -1,0 +1,40 @@
+function hs52(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (4 * x[1] - x[2])^2 + (x[2] + x[3] - 2)^2 + (x[4] - 1)^2 + (x[5] - 1)^2,
+    2 * ones(T, 5),
+    x -> [x[1] + 3 * x[2]; x[3] + x[4] - 2 * x[5]; x[2] - x[5]],
+    zeros(T, 3),
+    zeros(T, 3),
+    name = "hs52_autodiff";
+    kwargs...,
+  )
+end
+
+hs52_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 3,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 15,
+  :minimize => true,
+  :name => "hs52",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs52_meta(; n::Integer = default_nvar) = (hs52_meta[:nvar], hs52_meta[:ncon])

--- a/src/ADNLPProblems/hs56.jl
+++ b/src/ADNLPProblems/hs56.jl
@@ -1,0 +1,53 @@
+function hs56(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> -x[1] * x[2] * x[3],
+    T[
+      1.0,
+      1.0,
+      1.0,
+      asin(sqrt(1 / 4.2)),
+      asin(sqrt(1 / 4.2)),
+      asin(sqrt(1 / 4.2)),
+      asin(sqrt(5 / 7.2)),
+    ],
+    x -> [
+      x[1] - T(4.2) * sin(x[4])^2
+      x[2] - T(4.2) * sin(x[5])^2
+      x[3] - T(4.2) * sin(x[6])^2
+      x[1] + 2 * x[2] + 2 * x[3] - 7.2 * sin(x[7])^2
+    ],
+    zeros(T, 4),
+    zeros(T, 4),
+    name = "hs56_autodiff";
+    kwargs...,
+  )
+end
+
+hs56_meta = Dict(
+  :nvar => 7,
+  :variable_size => false,
+  :ncon => 4,
+  :variable_con_size => false,
+  :nnzo => 7,
+  :nnzh => 28,
+  :nnzj => 28,
+  :minimize => true,
+  :name => "hs56",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :other,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs56_meta(; n::Integer = default_nvar) = (hs56_meta[:nvar], hs56_meta[:ncon])

--- a/src/ADNLPProblems/hs56.jl
+++ b/src/ADNLPProblems/hs56.jl
@@ -1,5 +1,5 @@
 function hs56(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> -x[1] * x[2] * x[3],
     T[
       1.0,

--- a/src/ADNLPProblems/hs6.jl
+++ b/src/ADNLPProblems/hs6.jl
@@ -1,0 +1,40 @@
+function hs6(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - 1)^2,
+    T[-1.2; 1.0],
+    x -> [10 * (x[2] - x[1]^2)],
+    zeros(T, 1),
+    zeros(T, 1),
+    name = "hs6_autodiff";
+    kwargs...,
+  )
+end
+
+hs6_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 1,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 2,
+  :minimize => true,
+  :name => "hs6",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs6_meta(; n::Integer = default_nvar) = (hs6_meta[:nvar], hs6_meta[:ncon])

--- a/src/ADNLPProblems/hs6.jl
+++ b/src/ADNLPProblems/hs6.jl
@@ -1,5 +1,5 @@
 function hs6(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - 1)^2,
     T[-1.2; 1.0],
     x -> [10 * (x[2] - x[1]^2)],

--- a/src/ADNLPProblems/hs63.jl
+++ b/src/ADNLPProblems/hs63.jl
@@ -1,0 +1,40 @@
+function hs63(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> 1000 - x[1]^2 - 2 * x[2]^2 - x[3]^2 - x[1] * x[2] - x[1] * x[3],
+    2 * ones(T, 3),
+    x -> [8 * x[1] + 14 * x[2] + 7 * x[3] - 56; x[1]^2 + x[2]^2 + x[3]^2 - 25],
+    zeros(T, 2),
+    zeros(T, 2),
+    name = "hs63_autodiff";
+    kwargs...,
+  )
+end
+
+hs63_meta = Dict(
+  :nvar => 3,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 3,
+  :nnzh => 6,
+  :nnzj => 6,
+  :minimize => true,
+  :name => "hs63",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :quadratic,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs63_meta(; n::Integer = default_nvar) = (hs63_meta[:nvar], hs63_meta[:ncon])

--- a/src/ADNLPProblems/hs63.jl
+++ b/src/ADNLPProblems/hs63.jl
@@ -1,5 +1,5 @@
 function hs63(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> 1000 - x[1]^2 - 2 * x[2]^2 - x[3]^2 - x[1] * x[2] - x[1] * x[3],
     2 * ones(T, 3),
     x -> [8 * x[1] + 14 * x[2] + 7 * x[3] - 56; x[1]^2 + x[2]^2 + x[3]^2 - 25],

--- a/src/ADNLPProblems/hs7.jl
+++ b/src/ADNLPProblems/hs7.jl
@@ -1,0 +1,40 @@
+function hs7(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> log(1 + x[1]^2) - x[2],
+    T[2.0; 2.0],
+    x -> [(1 + x[1]^2)^2 + x[2]^2 - 4],
+    zeros(T, 1),
+    zeros(T, 1),
+    name = "hs7_autodiff";
+    kwargs...,
+  )
+end
+
+hs7_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 1,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 2,
+  :minimize => true,
+  :name => "hs7",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :other,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs7_meta(; n::Integer = default_nvar) = (hs7_meta[:nvar], hs7_meta[:ncon])

--- a/src/ADNLPProblems/hs7.jl
+++ b/src/ADNLPProblems/hs7.jl
@@ -1,5 +1,5 @@
 function hs7(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> log(1 + x[1]^2) - x[2],
     T[2.0; 2.0],
     x -> [(1 + x[1]^2)^2 + x[2]^2 - 4],

--- a/src/ADNLPProblems/hs77.jl
+++ b/src/ADNLPProblems/hs77.jl
@@ -1,0 +1,44 @@
+function hs77(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - 1)^2 + (x[1] - x[2])^2 + (x[3] - 1)^2 + (x[4] - 1)^4 + (x[5] - 1)^6,
+    2 * ones(T, 5),
+    x -> [
+      x[1] + x[2]^2 + x[3]^3 - 2 - 3 * T(sqrt(2))
+      x[2] - x[3]^2 + x[4] + 2 - 2 * T(sqrt(2))
+      x[1] * x[5] - 2
+    ],
+    zeros(T, 3),
+    zeros(T, 3),
+    name = "hs77_autodiff";
+    kwargs...,
+  )
+end
+
+hs77_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 3,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 15,
+  :minimize => true,
+  :name => "hs77",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :sum_of_squares,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs77_meta(; n::Integer = default_nvar) = (hs77_meta[:nvar], hs77_meta[:ncon])

--- a/src/ADNLPProblems/hs77.jl
+++ b/src/ADNLPProblems/hs77.jl
@@ -1,5 +1,5 @@
 function hs77(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - 1)^2 + (x[1] - x[2])^2 + (x[3] - 1)^2 + (x[4] - 1)^4 + (x[5] - 1)^6,
     2 * ones(T, 5),
     x -> [

--- a/src/ADNLPProblems/hs79.jl
+++ b/src/ADNLPProblems/hs79.jl
@@ -1,5 +1,5 @@
 function hs79(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> (x[1] - 1)^2 + (x[1] - x[2])^2 + (x[2] - x[3])^2 + (x[3] - x[4])^4 + (x[4] - x[5])^4,
     2 * ones(T, 5),
     x -> [

--- a/src/ADNLPProblems/hs79.jl
+++ b/src/ADNLPProblems/hs79.jl
@@ -1,0 +1,44 @@
+function hs79(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> (x[1] - 1)^2 + (x[1] - x[2])^2 + (x[2] - x[3])^2 + (x[3] - x[4])^4 + (x[4] - x[5])^4,
+    2 * ones(T, 5),
+    x -> [
+      x[1] + x[2]^2 + x[3]^3 - 2 - 3 * T(sqrt(2))
+      x[2] - x[3]^2 + x[4] + 2 - 2 * T(sqrt(2))
+      x[1] * x[5] - 2
+    ],
+    zeros(T, 3),
+    zeros(T, 3),
+    name = "hs79_autodiff";
+    kwargs...,
+  )
+end
+
+hs79_meta = Dict(
+  :nvar => 5,
+  :variable_size => false,
+  :ncon => 3,
+  :variable_con_size => false,
+  :nnzo => 5,
+  :nnzh => 15,
+  :nnzj => 15,
+  :minimize => true,
+  :name => "hs79",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :sum_of_squares,
+  :contype => :general,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs79_meta(; n::Integer = default_nvar) = (hs79_meta[:nvar], hs79_meta[:ncon])

--- a/src/ADNLPProblems/hs8.jl
+++ b/src/ADNLPProblems/hs8.jl
@@ -1,5 +1,5 @@
 function hs8(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> -T(1),
     T[2.0; 1.0],
     x -> [x[1]^2 + x[2]^2 - 25; x[1] * x[2] - 9],

--- a/src/ADNLPProblems/hs8.jl
+++ b/src/ADNLPProblems/hs8.jl
@@ -1,0 +1,40 @@
+function hs8(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> -T(1),
+    T[2.0; 1.0],
+    x -> [x[1]^2 + x[2]^2 - 25; x[1] * x[2] - 9],
+    zeros(T, 2),
+    zeros(T, 2),
+    name = "hs8_autodiff";
+    kwargs...,
+  )
+end
+
+hs8_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 4,
+  :minimize => true,
+  :name => "hs8",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :constant,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs8_meta(; n::Integer = default_nvar) = (hs8_meta[:nvar], hs8_meta[:ncon])

--- a/src/ADNLPProblems/hs9.jl
+++ b/src/ADNLPProblems/hs9.jl
@@ -1,5 +1,5 @@
 function hs9(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  return ADNLPModel(
+  return ADNLPModels.ADNLPModel(
     x -> sin(π * x[1] / 12) * cos(π * x[2] / 16),
     zeros(T, 2),
     x -> [4 * x[1] - 3 * x[2]],

--- a/src/ADNLPProblems/hs9.jl
+++ b/src/ADNLPProblems/hs9.jl
@@ -1,0 +1,40 @@
+function hs9(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  return ADNLPModel(
+    x -> sin(π * x[1] / 12) * cos(π * x[2] / 16),
+    zeros(T, 2),
+    x -> [4 * x[1] - 3 * x[2]],
+    zeros(T, 1),
+    zeros(T, 1),
+    name = "hs9_autodiff";
+    kwargs...,
+  )
+end
+
+hs9_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 1,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 2,
+  :minimize => true,
+  :name => "hs9",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :other,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_hs9_meta(; n::Integer = default_nvar) = (hs9_meta[:nvar], hs9_meta[:ncon])

--- a/src/ADNLPProblems/indef_mod.jl
+++ b/src/ADNLPProblems/indef_mod.jl
@@ -1,0 +1,43 @@
+function indef_mod(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 3 || error("indef : n ≥ 3")
+  function f(x)
+    n = length(x)
+    return 100 * sum(sin(x[i] / 100) for i = 1:n) +
+           T(0.5) * sum(cos(2 * x[i] - x[n] - x[1]) for i = 2:(n - 1))
+  end
+  x0 = T.([(i / (n + 1)) for i = 1:n])
+  return ADNLPModel(f, x0, name = "indef_autodiff"; kwargs...)
+end
+
+indef_mod_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "indef_mod",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_indef_mod_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/indef_mod.jl
+++ b/src/ADNLPProblems/indef_mod.jl
@@ -10,7 +10,7 @@ function indef_mod(;
            T(0.5) * sum(cos(2 * x[i] - x[n] - x[1]) for i = 2:(n - 1))
   end
   x0 = T.([(i / (n + 1)) for i = 1:n])
-  return ADNLPModel(f, x0, name = "indef_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "indef_autodiff"; kwargs...)
 end
 
 indef_mod_meta = Dict(

--- a/src/ADNLPProblems/liarwhd.jl
+++ b/src/ADNLPProblems/liarwhd.jl
@@ -5,7 +5,7 @@ function liarwhd(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     return sum(4 * (x[i]^2 - x[1])^2 + (x[i] - 1)^2 for i = 1:n)
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "liarwhd_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "liarwhd_autodiff"; kwargs...)
 end
 
 liarwhd_meta = Dict(

--- a/src/ADNLPProblems/liarwhd.jl
+++ b/src/ADNLPProblems/liarwhd.jl
@@ -1,0 +1,38 @@
+function liarwhd(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 2 || error("liarwhd : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return sum(4 * (x[i]^2 - x[1])^2 + (x[i] - 1)^2 for i = 1:n)
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "liarwhd_autodiff"; kwargs...)
+end
+
+liarwhd_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "liarwhd",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_liarwhd_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/lincon.jl
+++ b/src/ADNLPProblems/lincon.jl
@@ -1,0 +1,54 @@
+function lincon(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  A = [1 2; 3 4]
+  b = [5; 6]
+  B = LinearAlgebra.diagm([3 * i for i = 3:5])
+  c = [1; 2; 3]
+  C = [0 -2; 4 0]
+  d = [1; -1]
+
+  x0 = zeros(T, 15)
+  f(x) = sum(i + x[i]^4 for i = 1:15)
+  con(x) = T[
+    15 * x[15]
+    c' * x[10:12]
+    d' * x[13:14]
+    b' * x[8:9]
+    C * x[6:7]
+    A * x[1:2]
+    B * x[3:5]
+  ]
+
+  lcon = T[22; 1; -Inf; -11; -d; -b; -Inf * ones(3)]
+  ucon = T[22; Inf; 16; 9; -d; Inf * ones(2); c]
+
+  return ADNLPModel(f, x0, con, lcon, ucon, name = "lincon_autodiff"; kwargs...)
+end
+
+lincon_meta = Dict(
+  :nvar => 15,
+  :variable_size => false,
+  :ncon => 11,
+  :variable_con_size => false,
+  :nnzo => 15,
+  :nnzh => 120,
+  :nnzj => 165,
+  :minimize => true,
+  :name => "lincon",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :other,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_lincon_meta(; n::Integer = default_nvar) = (lincon_meta[:nvar], lincon_meta[:ncon])

--- a/src/ADNLPProblems/lincon.jl
+++ b/src/ADNLPProblems/lincon.jl
@@ -21,7 +21,7 @@ function lincon(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
   lcon = T[22; 1; -Inf; -11; -d; -b; -Inf * ones(3)]
   ucon = T[22; Inf; 16; 9; -d; Inf * ones(2); c]
 
-  return ADNLPModel(f, x0, con, lcon, ucon, name = "lincon_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, con, lcon, ucon, name = "lincon_autodiff"; kwargs...)
 end
 
 lincon_meta = Dict(

--- a/src/ADNLPProblems/linsv.jl
+++ b/src/ADNLPProblems/linsv.jl
@@ -5,7 +5,7 @@ function linsv(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   lcon = T[3; 1]
   ucon = T[Inf; Inf]
 
-  return ADNLPModel(f, x0, con, lcon, ucon, name = "linsv_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, con, lcon, ucon, name = "linsv_autodiff"; kwargs...)
 end
 
 linsv_meta = Dict(

--- a/src/ADNLPProblems/linsv.jl
+++ b/src/ADNLPProblems/linsv.jl
@@ -1,0 +1,38 @@
+function linsv(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  x0 = zeros(T, 2)
+  f(x) = x[1]
+  con(x) = T[x[1] + x[2]; x[2]]
+  lcon = T[3; 1]
+  ucon = T[Inf; Inf]
+
+  return ADNLPModel(f, x0, con, lcon, ucon, name = "linsv_autodiff"; kwargs...)
+end
+
+linsv_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 4,
+  :minimize => true,
+  :name => "linsv",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :linear,
+  :contype => :linear,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => true,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_linsv_meta(; n::Integer = default_nvar) = (linsv_meta[:nvar], linsv_meta[:ncon])

--- a/src/ADNLPProblems/mgh01feas.jl
+++ b/src/ADNLPProblems/mgh01feas.jl
@@ -1,0 +1,42 @@
+function mgh01feas(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  x0 = T[-1.2; 1.0]
+  f(x) = zero(T)
+  c(x) = T[1 - x[1]; 10 * (x[2] - x[1]^2)]
+  lcon = zeros(T, 2)
+  ucon = zeros(T, 2)
+
+  return ADNLPModel(f, x0, c, lcon, ucon, name = "mgh01feas_autodiff"; kwargs...)
+end
+
+mgh01feas_meta = Dict(
+  :nvar => 2,
+  :variable_size => false,
+  :ncon => 2,
+  :variable_con_size => false,
+  :nnzo => 2,
+  :nnzh => 3,
+  :nnzj => 4,
+  :minimize => true,
+  :name => "mgh01feas",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => missing,
+  :objtype => :constant,
+  :contype => :quadratic,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => true,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_mgh01feas_meta(; n::Integer = default_nvar) = (mgh01feas_meta[:nvar], mgh01feas_meta[:ncon])

--- a/src/ADNLPProblems/mgh01feas.jl
+++ b/src/ADNLPProblems/mgh01feas.jl
@@ -9,7 +9,7 @@ function mgh01feas(;
   lcon = zeros(T, 2)
   ucon = zeros(T, 2)
 
-  return ADNLPModel(f, x0, c, lcon, ucon, name = "mgh01feas_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "mgh01feas_autodiff"; kwargs...)
 end
 
 mgh01feas_meta = Dict(

--- a/src/ADNLPProblems/morebv.jl
+++ b/src/ADNLPProblems/morebv.jl
@@ -12,7 +12,7 @@ function morebv(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
   x0[1] = zero(T)
   x0[n] = zero(T)
 
-  return ADNLPModel(f, x0, name = "morebv_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "morebv_autodiff"; kwargs...)
 end
 
 morebv_meta = Dict(

--- a/src/ADNLPProblems/morebv.jl
+++ b/src/ADNLPProblems/morebv.jl
@@ -1,0 +1,45 @@
+function morebv(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 2 || error("morebv : n ≥ 2")
+  function f(x)
+    n = length(x)
+    h = T(1 / (n - 1))
+    return sum(
+      (2 * x[i] - x[i - 1] - x[i + 1] + (h^2 / 2) * (x[i] + (i - 1) * h + 1)^3)^2 for i = 2:(n - 1)
+    )
+  end
+
+  x0 = ones(T, n) / 2
+  x0[1] = zero(T)
+  x0[n] = zero(T)
+
+  return ADNLPModel(f, x0, name = "morebv_autodiff"; kwargs...)
+end
+
+morebv_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "morebv",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_morebv_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/ncb20.jl
+++ b/src/ADNLPProblems/ncb20.jl
@@ -15,7 +15,7 @@ function ncb20(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   x0 = ones(T, n)
   x0[1:(n - 10)] .= zero(T)
 
-  return ADNLPModel(f, x0, name = "ncb20_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "ncb20_autodiff"; kwargs...)
 end
 
 ncb20_meta = Dict(

--- a/src/ADNLPProblems/ncb20.jl
+++ b/src/ADNLPProblems/ncb20.jl
@@ -1,0 +1,48 @@
+function ncb20(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 31 || error("ncb20 : n ≥ 31")
+  function f(x)
+    n = length(x)
+    h = T(1 / (n - 1))
+    return 2 +
+           sum(
+             T(10 / i) * (sum(x[i + j - 1] / (1 + x[i + j - 1]^2) for j = 1:20))^2 -
+             T(0.2) * sum(x[i + j - 1] for j = 1:20) for i = 1:(n - 30)
+           ) +
+           sum(x[i]^4 + 2 for i = 1:(n - 10)) +
+           T(1.0e-4) * sum(x[i] * x[i + 10] * x[i + n - 10] + 2 * x[i + n - 10]^2 for i = 1:10)
+  end
+
+  x0 = ones(T, n)
+  x0[1:(n - 10)] .= zero(T)
+
+  return ADNLPModel(f, x0, name = "ncb20_autodiff"; kwargs...)
+end
+
+ncb20_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "ncb20",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_ncb20_meta(; n::Int = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/ncb20b.jl
+++ b/src/ADNLPProblems/ncb20b.jl
@@ -1,0 +1,42 @@
+function ncb20b(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 20 || error("ncb20 : n ≥ 20")
+  function f(x)
+    n = length(x)
+    h = T(1 / (n - 1))
+    return sum(
+      T(10 / i) * (sum(x[i + j - 1] / (1 + x[i + j - 1]^2) for j = 1:20))^2 -
+      T(0.2) * sum(x[i + j - 1] for j = 1:20) for i = 1:(n - 19)
+    ) + sum(100 * x[i]^4 + 2 for i = 1:n)
+  end
+  x0 = zeros(T, n)
+  return ADNLPModel(f, x0, name = "ncb20b_autodiff"; kwargs...)
+end
+
+ncb20b_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "ncb20b",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_ncb20b_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/ncb20b.jl
+++ b/src/ADNLPProblems/ncb20b.jl
@@ -9,7 +9,7 @@ function ncb20b(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
     ) + sum(100 * x[i]^4 + 2 for i = 1:n)
   end
   x0 = zeros(T, n)
-  return ADNLPModel(f, x0, name = "ncb20b_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "ncb20b_autodiff"; kwargs...)
 end
 
 ncb20b_meta = Dict(

--- a/src/ADNLPProblems/noncvxu2.jl
+++ b/src/ADNLPProblems/noncvxu2.jl
@@ -12,7 +12,7 @@ function noncvxu2(;
     )
   end
   x0 = T.([i for i = 1:n])
-  return ADNLPModel(f, x0, name = "noncvxu2_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "noncvxu2_autodiff"; kwargs...)
 end
 
 noncvxu2_meta = Dict(

--- a/src/ADNLPProblems/noncvxu2.jl
+++ b/src/ADNLPProblems/noncvxu2.jl
@@ -1,0 +1,45 @@
+function noncvxu2(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || error("noncvxu2 : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return sum(
+      (x[i] + x[mod(3 * i - 2, n) + 1] + x[mod(7 * i - 3, n) + 1])^2 +
+      4 * cos(x[i] + x[mod(3 * i - 2, n) + 1] + x[mod(7 * i - 3, n) + 1]) for i = 1:n
+    )
+  end
+  x0 = T.([i for i = 1:n])
+  return ADNLPModel(f, x0, name = "noncvxu2_autodiff"; kwargs...)
+end
+
+noncvxu2_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "noncvxu2",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_noncvxu2_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/noncvxun.jl
+++ b/src/ADNLPProblems/noncvxun.jl
@@ -12,7 +12,7 @@ function noncvxun(;
     )
   end
   x0 = T.([i for i = 1:n])
-  return ADNLPModel(f, x0, name = "noncvxun_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "noncvxun_autodiff"; kwargs...)
 end
 
 noncvxun_meta = Dict(

--- a/src/ADNLPProblems/noncvxun.jl
+++ b/src/ADNLPProblems/noncvxun.jl
@@ -1,0 +1,45 @@
+function noncvxun(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || error("noncvxun : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return sum(
+      (x[i] + x[mod(2 * i - 1, n) + 1] + x[mod(3 * i - 1, n) + 1])^2 +
+      4 * cos(x[i] + x[mod(2 * i - 1, n) + 1] + x[mod(3 * i - 1, n) + 1]) for i = 1:n
+    )
+  end
+  x0 = T.([i for i = 1:n])
+  return ADNLPModel(f, x0, name = "noncvxun_autodiff"; kwargs...)
+end
+
+noncvxun_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "noncvxun",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_noncvxun_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/nondia.jl
+++ b/src/ADNLPProblems/nondia.jl
@@ -1,0 +1,38 @@
+function nondia(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 2 || error("nondia : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return (x[1] - 1)^2 + sum((100 * x[1] - x[i - 1]^2)^2 for i = 2:n)
+  end
+  x0 = -ones(T, n)
+  return ADNLPModel(f, x0, name = "nondia_autodiff"; kwargs...)
+end
+
+nondia_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "nondia",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_nondia_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/nondia.jl
+++ b/src/ADNLPProblems/nondia.jl
@@ -5,7 +5,7 @@ function nondia(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
     return (x[1] - 1)^2 + sum((100 * x[1] - x[i - 1]^2)^2 for i = 2:n)
   end
   x0 = -ones(T, n)
-  return ADNLPModel(f, x0, name = "nondia_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "nondia_autodiff"; kwargs...)
 end
 
 nondia_meta = Dict(

--- a/src/ADNLPProblems/nondquar.jl
+++ b/src/ADNLPProblems/nondquar.jl
@@ -1,0 +1,43 @@
+function nondquar(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  function f(x)
+    n = length(x)
+    return (x[1] - x[2])^2 + (x[n - 1] - x[n])^2 + sum((x[i] + x[i + 1] + x[n])^4 for i = 1:(n - 2))
+  end
+
+  x0 = ones(T, n)
+  x0[2 * collect(1:div(n, 2))] .= -one(T)
+  return ADNLPModel(f, x0, name = "nondquar_autodiff"; kwargs...)
+end
+
+nondquar_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "nondquar",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_nondquar_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/nondquar.jl
+++ b/src/ADNLPProblems/nondquar.jl
@@ -10,7 +10,7 @@ function nondquar(;
 
   x0 = ones(T, n)
   x0[2 * collect(1:div(n, 2))] .= -one(T)
-  return ADNLPModel(f, x0, name = "nondquar_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "nondquar_autodiff"; kwargs...)
 end
 
 nondquar_meta = Dict(

--- a/src/ADNLPProblems/penalty2.jl
+++ b/src/ADNLPProblems/penalty2.jl
@@ -18,7 +18,7 @@ function penalty2(;
            (sum((n - j + 1) * x[j]^2 for j = 1:n) - 1)^2
   end
   x0 = ones(T, n) / 2
-  return ADNLPModel(f, x0, name = "penalty2_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "penalty2_autodiff"; kwargs...)
 end
 
 penalty2_meta = Dict(

--- a/src/ADNLPProblems/penalty2.jl
+++ b/src/ADNLPProblems/penalty2.jl
@@ -1,0 +1,51 @@
+function penalty2(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 3 || error("penalty2 : n ≥ 3")
+  function f(x)
+    n = length(x)
+    a = T(1.0e-5)
+    m = 2 * n
+    y = ones(T, m)
+    for i = 1:m
+      y[i] = exp(i / 10) + exp((i - 1) / 10)
+    end
+    return (x[1] - T(0.2))^2 +
+           sum(a * (exp(x[i] / 10) + exp(x[i - 1] / 10) - y[i])^2 for i = 2:n) +
+           sum(a * (exp(x[i - n + 1] / 10) - T(exp(-1 / 10)))^2 for i = (n + 1):(2 * n - 1)) +
+           (sum((n - j + 1) * x[j]^2 for j = 1:n) - 1)^2
+  end
+  x0 = ones(T, n) / 2
+  return ADNLPModel(f, x0, name = "penalty2_autodiff"; kwargs...)
+end
+
+penalty2_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "penalty2",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_penalty2_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/penalty3.jl
+++ b/src/ADNLPProblems/penalty3.jl
@@ -1,0 +1,48 @@
+function penalty3(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 3 || error("penalty3 : n ≥ 3")
+  function f(x)
+    n = length(x)
+    return 1 +
+           sum((x[i] - 1)^2 for i = 1:div(n, 2)) +
+           exp(x[n]) * sum((x[i] + 2 * x[i + 1] + 10 * x[i + 2] - 1)^2 for i = 1:(n - 2)) +
+           sum((x[i] + 2 * x[i + 1] + 10 * x[i + 2] - 1)^2 for i = 1:(n - 2)) *
+           sum((2 * x[i] + x[i + 1] - 3)^2 for i = 1:(n - 2)) +
+           exp(x[n - 1]) * sum((2 * x[i] + x[i + 1] - 3)^2 for i = 1:(n - 2)) +
+           (sum(x[i]^2 - n for i = 1:n))^2
+  end
+  x0 = T.([i / (n + 1) for i = 1:n])
+  return ADNLPModel(f, x0, name = "penalty3_autodiff"; kwargs...)
+end
+
+penalty3_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "penalty3",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_penalty3_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/penalty3.jl
+++ b/src/ADNLPProblems/penalty3.jl
@@ -15,7 +15,7 @@ function penalty3(;
            (sum(x[i]^2 - n for i = 1:n))^2
   end
   x0 = T.([i / (n + 1) for i = 1:n])
-  return ADNLPModel(f, x0, name = "penalty3_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "penalty3_autodiff"; kwargs...)
 end
 
 penalty3_meta = Dict(

--- a/src/ADNLPProblems/powellsg.jl
+++ b/src/ADNLPProblems/powellsg.jl
@@ -1,0 +1,45 @@
+function powellsg(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n = 4 * max(1, div(n, 4))  # number of variables adjusted to be a multiple of 4
+  function f(x)
+    n = length(x)
+    return sum(
+      -(1 / (1 + (x[i] - x[i + 1])^2)) - sin((π * x[i + 1] + x[i + 2]) / 2) -
+      exp(-((x[i] + x[i + 2]) / x[i + 1] - 2)^2) for i = 1:(n - 2)
+    )
+  end
+  x0 = 3 * ones(T, n)
+  return ADNLPModel(f, x0, name = "powellsg_autodiff"; kwargs...)
+end
+
+powellsg_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "powellsg",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => UInt8(0),
+  :not_everywhere_defined => true, # not defined in 0
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_powellsg_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/powellsg.jl
+++ b/src/ADNLPProblems/powellsg.jl
@@ -12,7 +12,7 @@ function powellsg(;
     )
   end
   x0 = 3 * ones(T, n)
-  return ADNLPModel(f, x0, name = "powellsg_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "powellsg_autodiff"; kwargs...)
 end
 
 powellsg_meta = Dict(

--- a/src/ADNLPProblems/power.jl
+++ b/src/ADNLPProblems/power.jl
@@ -1,0 +1,37 @@
+function power(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return (sum((i * x[i]^2) for i = 1:n))^2
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "power_autodiff"; kwargs...)
+end
+
+power_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "power",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_power_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/power.jl
+++ b/src/ADNLPProblems/power.jl
@@ -4,7 +4,7 @@ function power(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
     return (sum((i * x[i]^2) for i = 1:n))^2
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "power_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "power_autodiff"; kwargs...)
 end
 
 power_meta = Dict(

--- a/src/ADNLPProblems/quartc.jl
+++ b/src/ADNLPProblems/quartc.jl
@@ -4,7 +4,7 @@ function quartc(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
     return sum((x[i] - i)^4 for i = 1:n)
   end
   x0 = 2 * ones(T, n)
-  return ADNLPModel(f, x0, name = "quartc_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "quartc_autodiff"; kwargs...)
 end
 
 quartc_meta = Dict(

--- a/src/ADNLPProblems/quartc.jl
+++ b/src/ADNLPProblems/quartc.jl
@@ -1,0 +1,37 @@
+function quartc(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return sum((x[i] - i)^4 for i = 1:n)
+  end
+  x0 = 2 * ones(T, n)
+  return ADNLPModel(f, x0, name = "quartc_autodiff"; kwargs...)
+end
+
+quartc_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "quartc",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_quartc_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/sbrybnd.jl
+++ b/src/ADNLPProblems/sbrybnd.jl
@@ -1,0 +1,50 @@
+function sbrybnd(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 2 || error("sbrybnd : n ≥ 2")
+  p = zeros(T, n)
+  J = Array{Any}(undef, n)
+  for i = 1:n
+    p[i] = exp(6 * (i - 1) / (n - 1))
+    J[i] = [max(1, i - 5):(i - 1); (i + 1):min(n, i + 1)]
+  end
+
+  function f(x)
+    n = length(x)
+    return sum(
+      (
+        (2 + 5 * p[i]^2 * x[i]^2) * p[i] * x[i] + 1 -
+        sum(p[j] * x[j] * (1 + p[j] * x[j]) for j in J[i])
+      )^2 for i = 1:n
+    )
+  end
+  x0 = T.([1 / p[i] for i = 1:n])
+  return ADNLPModel(f, x0, name = "sbrybnd_autodiff"; kwargs...)
+end
+
+sbrybnd_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "sbrybnd",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_sbrybnd_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/sbrybnd.jl
+++ b/src/ADNLPProblems/sbrybnd.jl
@@ -17,7 +17,7 @@ function sbrybnd(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     )
   end
   x0 = T.([1 / p[i] for i = 1:n])
-  return ADNLPModel(f, x0, name = "sbrybnd_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "sbrybnd_autodiff"; kwargs...)
 end
 
 sbrybnd_meta = Dict(

--- a/src/ADNLPProblems/schmvett.jl
+++ b/src/ADNLPProblems/schmvett.jl
@@ -1,0 +1,44 @@
+function schmvett(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  function f(x)
+    n = length(x)
+    return sum(
+      -(1 / (1 + (x[i] - x[i + 1])^2)) - sin((π * x[i + 1] + x[i + 2]) / 2) -
+      exp(-((x[i] + x[i + 2]) / x[i + 1] - 2)^2) for i = 1:(n - 2)
+    )
+  end
+  x0 = 3 * ones(T, n)
+  return ADNLPModel(f, x0, name = "schmvett_autodiff"; kwargs...)
+end
+
+schmvett_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "schmvett",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => UInt8(0),
+  :not_everywhere_defined => true, # not defined in 0
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_schmvett_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/schmvett.jl
+++ b/src/ADNLPProblems/schmvett.jl
@@ -11,7 +11,7 @@ function schmvett(;
     )
   end
   x0 = 3 * ones(T, n)
-  return ADNLPModel(f, x0, name = "schmvett_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "schmvett_autodiff"; kwargs...)
 end
 
 schmvett_meta = Dict(

--- a/src/ADNLPProblems/scosine.jl
+++ b/src/ADNLPProblems/scosine.jl
@@ -9,7 +9,7 @@ function scosine(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
     return sum(cos(p[i]^2 * x[i]^2 - p[i + 1] * x[i + 1] / 2) for i = 1:(n - 1))
   end
   x0 = T.([1 / p[i] for i = 1:n])
-  return ADNLPModel(f, x0, name = "scosine_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "scosine_autodiff"; kwargs...)
 end
 
 scosine_meta = Dict(

--- a/src/ADNLPProblems/scosine.jl
+++ b/src/ADNLPProblems/scosine.jl
@@ -1,0 +1,42 @@
+function scosine(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n ≥ 2 || error("scosine : n ≥ 2")
+  p = zeros(T, n)
+  for i = 1:n
+    p[i] = exp(6 * (i - 1) / (n - 1))
+  end
+  function f(x)
+    n = length(x)
+    return sum(cos(p[i]^2 * x[i]^2 - p[i + 1] * x[i + 1] / 2) for i = 1:(n - 1))
+  end
+  x0 = T.([1 / p[i] for i = 1:n])
+  return ADNLPModel(f, x0, name = "scosine_autodiff"; kwargs...)
+end
+
+scosine_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "scosine",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_scosine_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/sinquad.jl
+++ b/src/ADNLPProblems/sinquad.jl
@@ -6,7 +6,7 @@ function sinquad(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
            sum((sin(x[i] - x[n]) - x[1]^2 + x[i]^2)^2 for i = 2:(n - 1))
   end
   x0 = ones(T, n) / 10
-  return ADNLPModel(f, x0, name = "sinquad_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "sinquad_autodiff"; kwargs...)
 end
 
 sinquad_meta = Dict(

--- a/src/ADNLPProblems/sinquad.jl
+++ b/src/ADNLPProblems/sinquad.jl
@@ -1,0 +1,39 @@
+function sinquad(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return (x[1] - 4)^4 +
+           (x[n]^2 - x[1]^2)^2 +
+           sum((sin(x[i] - x[n]) - x[1]^2 + x[i]^2)^2 for i = 2:(n - 1))
+  end
+  x0 = ones(T, n) / 10
+  return ADNLPModel(f, x0, name = "sinquad_autodiff"; kwargs...)
+end
+
+sinquad_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "sinquad",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_sinquad_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/sparsine.jl
+++ b/src/ADNLPProblems/sparsine.jl
@@ -19,7 +19,7 @@ function sparsine(;
     )
   end
   x0 = ones(T, n) / 2
-  return ADNLPModel(f, x0, name = "sparsine_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "sparsine_autodiff"; kwargs...)
 end
 
 sparsine_meta = Dict(

--- a/src/ADNLPProblems/sparsine.jl
+++ b/src/ADNLPProblems/sparsine.jl
@@ -1,0 +1,52 @@
+function sparsine(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 10 || error("sparsine : n ≥ 10")
+  function f(x)
+    n = length(x)
+    return T(0.5) * sum(
+      i *
+      (
+        sin(x[i]) +
+        sin(x[mod(2 * i - 1, n) + 1]) +
+        sin(x[mod(3 * i - 1, n) + 1]) +
+        sin(x[mod(5 * i - 1, n) + 1]) +
+        sin(x[mod(7 * i - 1, n) + 1]) +
+        sin(x[mod(11 * i - 1, n) + 1])
+      )^2 for i = 1:n
+    )
+  end
+  x0 = ones(T, n) / 2
+  return ADNLPModel(f, x0, name = "sparsine_autodiff"; kwargs...)
+end
+
+sparsine_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "sparsine",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_sparsine_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/sparsqur.jl
+++ b/src/ADNLPProblems/sparsqur.jl
@@ -1,0 +1,52 @@
+function sparsqur(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 10 || error("sparsqur : n ≥ 10")
+  function f(x)
+    n = length(x)
+    return T(1 / 8) * sum(
+      i *
+      (
+        x[i]^2 +
+        x[mod(2 * i - 1, n) + 1]^2 +
+        x[mod(3 * i - 1, n) + 1]^2 +
+        x[mod(5 * i - 1, n) + 1]^2 +
+        x[mod(7 * i - 1, n) + 1]^2 +
+        x[mod(11 * i - 1, n) + 1]^2
+      )^2 for i = 1:n
+    )
+  end
+  x0 = ones(T, n) / 2
+  return ADNLPModel(f, x0, name = "sparsqur_autodiff"; kwargs...)
+end
+
+sparsqur_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "sparsqur",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_sparsqur_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/sparsqur.jl
+++ b/src/ADNLPProblems/sparsqur.jl
@@ -19,7 +19,7 @@ function sparsqur(;
     )
   end
   x0 = ones(T, n) / 2
-  return ADNLPModel(f, x0, name = "sparsqur_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "sparsqur_autodiff"; kwargs...)
 end
 
 sparsqur_meta = Dict(

--- a/src/ADNLPProblems/srosenbr.jl
+++ b/src/ADNLPProblems/srosenbr.jl
@@ -1,0 +1,45 @@
+function srosenbr(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n = 2 * max(1, div(n, 2))  # number of variables adjusted to be even
+  function f(x)
+    n = length(x)
+    return sum(100 * (x[2 * i] - x[2 * i - 1]^2)^2 + (x[2 * i - 1] - 1)^2 for i = 1:div(n, 2))
+  end
+
+  x0 = ones(T, n)
+  x0[2 * (collect(1:div(n, 2))) .- 1] .= -1.2
+
+  return ADNLPModel(f, x0, name = "srosenbr_autodiff"; kwargs...)
+end
+
+srosenbr_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "srosenbr",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_srosenbr_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/srosenbr.jl
+++ b/src/ADNLPProblems/srosenbr.jl
@@ -12,7 +12,7 @@ function srosenbr(;
   x0 = ones(T, n)
   x0[2 * (collect(1:div(n, 2))) .- 1] .= -1.2
 
-  return ADNLPModel(f, x0, name = "srosenbr_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "srosenbr_autodiff"; kwargs...)
 end
 
 srosenbr_meta = Dict(

--- a/src/ADNLPProblems/tointgss.jl
+++ b/src/ADNLPProblems/tointgss.jl
@@ -12,7 +12,7 @@ function tointgss(;
     )
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "tointgss_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "tointgss_autodiff"; kwargs...)
 end
 
 tointgss_meta = Dict(

--- a/src/ADNLPProblems/tointgss.jl
+++ b/src/ADNLPProblems/tointgss.jl
@@ -1,0 +1,45 @@
+function tointgss(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 3 || error("tointgss : n ≥ 3")
+  function f(x)
+    n = length(x)
+    return sum(
+      (T(10 / (n + 2)) + x[i + 2]^2) * (2 - exp(-(x[i] - x[i + 1])^2 / (T(0.1) + x[i + 2]^2))) for
+      i = 1:(n - 2)
+    )
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "tointgss_autodiff"; kwargs...)
+end
+
+tointgss_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "tointgss",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :other,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_tointgss_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/tquartic.jl
+++ b/src/ADNLPProblems/tquartic.jl
@@ -1,0 +1,42 @@
+function tquartic(;
+  n::Int = default_nvar,
+  type::Val{T} = Val(Float64),
+  kwargs...,
+) where {T}
+  n ≥ 2 || error("tquartic : n ≥ 2")
+  function f(x)
+    n = length(x)
+    return (x[1] - 1)^2 + sum((x[1]^2 - x[i + 1]^2)^2 for i = 1:(n - 2))
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "tquartic_autodiff"; kwargs...)
+end
+
+tquartic_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "tquartic",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_tquartic_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/tquartic.jl
+++ b/src/ADNLPProblems/tquartic.jl
@@ -9,7 +9,7 @@ function tquartic(;
     return (x[1] - 1)^2 + sum((x[1]^2 - x[i + 1]^2)^2 for i = 1:(n - 2))
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "tquartic_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "tquartic_autodiff"; kwargs...)
 end
 
 tquartic_meta = Dict(

--- a/src/ADNLPProblems/tridia.jl
+++ b/src/ADNLPProblems/tridia.jl
@@ -1,0 +1,37 @@
+function tridia(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return (x[1] - 1)^2 + sum(i * (-x[i - 1] + 2 * x[i])^2 for i = 2:n)
+  end
+  x0 = ones(T, n)
+  return ADNLPModel(f, x0, name = "tridia_autodiff"; kwargs...)
+end
+
+tridia_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "tridia",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :quadratic,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_tridia_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/tridia.jl
+++ b/src/ADNLPProblems/tridia.jl
@@ -4,7 +4,7 @@ function tridia(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
     return (x[1] - 1)^2 + sum(i * (-x[i - 1] + 2 * x[i])^2 for i = 2:n)
   end
   x0 = ones(T, n)
-  return ADNLPModel(f, x0, name = "tridia_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "tridia_autodiff"; kwargs...)
 end
 
 tridia_meta = Dict(

--- a/src/ADNLPProblems/vardim.jl
+++ b/src/ADNLPProblems/vardim.jl
@@ -1,0 +1,40 @@
+function vardim(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function f(x)
+    n = length(x)
+    return sum((x[i] - 1)^2 for i = 1:n) +
+           sum(i * (x[i] - 1) for i = 1:n)^2 +
+           sum(i * (x[i] - 1) for i = 1:n)^4
+  end
+
+  x0 = T.([1 - i / n for i = 1:n])
+  return ADNLPModel(f, x0, name = "vardim_autodiff"; kwargs...)
+end
+
+vardim_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "vardim",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_vardim_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/ADNLPProblems/vardim.jl
+++ b/src/ADNLPProblems/vardim.jl
@@ -7,7 +7,7 @@ function vardim(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
   end
 
   x0 = T.([1 - i / n for i = 1:n])
-  return ADNLPModel(f, x0, name = "vardim_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "vardim_autodiff"; kwargs...)
 end
 
 vardim_meta = Dict(

--- a/src/ADNLPProblems/woods.jl
+++ b/src/ADNLPProblems/woods.jl
@@ -15,7 +15,7 @@ function woods(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   x0 = -3 * ones(T, n)
   x0[2 * (collect(1:div(n, 2)))] .= -one(T)
 
-  return ADNLPModel(f, x0, name = "woods_autodiff"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "woods_autodiff"; kwargs...)
 end
 
 woods_meta = Dict(

--- a/src/ADNLPProblems/woods.jl
+++ b/src/ADNLPProblems/woods.jl
@@ -1,0 +1,48 @@
+function woods(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n = 4 * max(1, div(n, 4))  # number of variables adjusted to be a multiple of 4
+  function f(x)
+    n = length(x)
+    return 1 + sum(
+      100 * (x[4 * i - 2] - x[4 * i - 3]^2)^2 +
+      (1 - x[4 * i - 3])^2 +
+      90 * (x[4 * i] - x[4 * i - 1]^2)^2 +
+      (1 - x[4 * i - 1])^2 +
+      10 * (x[4 * i - 2] + x[4 * i] - 2)^2 +
+      T(0.1) * (x[4 * i - 2] - x[4 * i])^2 for i = 1:div(n, 4)
+    )
+  end
+
+  x0 = -3 * ones(T, n)
+  x0[2 * (collect(1:div(n, 2)))] .= -one(T)
+
+  return ADNLPModel(f, x0, name = "woods_autodiff"; kwargs...)
+end
+
+woods_meta = Dict(
+  :nvar => default_nvar,
+  :variable_size => true,
+  :ncon => 0,
+  :variable_con_size => false,
+  :nnzo => 100,
+  :nnzh => 5050,
+  :nnzj => 0,
+  :minimize => true,
+  :name => "woods",
+  :optimal_value => NaN,
+  :has_multiple_solution => missing,
+  :is_infeasible => false,
+  :objtype => :sum_of_squares,
+  :contype => :unconstrained,
+  :origin => :unknown,
+  :deriv => typemax(UInt8),
+  :not_everywhere_defined => false,
+  :has_cvx_obj => false,
+  :has_cvx_con => false,
+  :has_equalities_only => false,
+  :has_inequalities_only => false,
+  :has_bounds => false,
+  :has_fixed_variables => false,
+  :cqs => 0,
+)
+
+get_woods_meta(; n::Integer = default_nvar) = (n, 0)

--- a/src/OptimizationProblems.jl
+++ b/src/OptimizationProblems.jl
@@ -1,5 +1,6 @@
 module OptimizationProblems
 
+include("ADNLPProblems/ADNLPProblems.jl")
 include("PureJuMP/PureJuMP.jl")
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,14 @@ for prob in names(OptimizationProblems.PureJuMP)
   prob_fn()
 end
 
+@test OptimizationProblems.ADNLPProblems.problems == []
+
+import ADNLPModels
+
 ndef = OptimizationProblems.ADNLPProblems.default_nvar
-for prob in names(OptimizationProblems.ADNLPProblems)
+for prob in OptimizationProblems.ADNLPProblems.problems
   prob == :ADNLPProblems && continue
+  println(prob)
   n, m = eval(Meta.parse("OptimizationProblems.ADNLPProblems.get_$(prob)_meta(n=$(2 * ndef))"))
   meta_pb = eval(Meta.parse("OptimizationProblems.ADNLPProblems.$(prob)_meta"))
   if meta_pb[:variable_size]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using OptimizationProblems, Test
+using NLPModels, OptimizationProblems, Test
 
 # Test that every problem can be instantiated.
 for prob in names(OptimizationProblems.PureJuMP)
@@ -6,4 +6,31 @@ for prob in names(OptimizationProblems.PureJuMP)
   println(prob)
   prob_fn = eval(Meta.parse("OptimizationProblems.PureJuMP.$(prob)"))
   prob_fn()
+end
+
+ndef = OptimizationProblems.ADNLPProblems.default_nvar
+for prob in names(OptimizationProblems.ADNLPProblems)
+  prob == :ADNLPProblems && continue
+  n, m = eval(Meta.parse("OptimizationProblems.ADNLPProblems.get_$(prob)_meta(n=$(2 * ndef))"))
+  meta_pb = eval(Meta.parse("OptimizationProblems.ADNLPProblems.$(prob)_meta"))
+  if meta_pb[:variable_size]
+    @test n != meta_pb[:nvar]
+  else
+    @test n == meta_pb[:nvar]
+  end
+  if meta_pb[:variable_con_size]
+    @test m != meta_pb[:ncon]
+  else
+    @test m == meta_pb[:ncon]
+  end
+
+  for T in [Float32, Float64]
+    nlp = eval(Meta.parse("OptimizationProblems.ADNLPProblems.$(prob)(type=$(Val(T)))"))
+    x0 = nlp.meta.x0
+    @test eltype(x0) == T
+    @test typeof(obj(nlp, x0)) == T
+    if nlp.meta.ncon > 0
+      @test typeof(obj(nlp, x0)) == T
+    end
+  end
 end


### PR DESCRIPTION
Bringing problems in ADNLPModels format #62 . These problems include a `meta` describing the problems.

Instead of using ADNLPModels directly, we could use `Requires` as the breakage tests of `ADNLPModels.jl` would be enough to see breaking releases.

145 problems from the PureJuMP submodule are missing here, and 3 problems here are not in PureJuMP.