### PR TITLE
Add linear constraint in ADModels

### DIFF
--- a/src/ADNLPProblems/hs105.jl
+++ b/src/ADNLPProblems/hs105.jl
@@ -48,5 +48,5 @@ function hs105(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   end
   lcon = -ones(T, 1)
   ucon = T(Inf) * ones(T, 1)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs105"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs105", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs106.jl
+++ b/src/ADNLPProblems/hs106.jl
@@ -21,5 +21,5 @@ function hs106(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   end
   lcon = vcat(-ones(T, 3), zeros(T, 3))
   ucon = T(Inf) * ones(T, 6)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs106"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs106", lin = [1, 2, 3]; kwargs...)
 end

--- a/src/ADNLPProblems/hs109.jl
+++ b/src/ADNLPProblems/hs109.jl
@@ -35,5 +35,5 @@ function hs109(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   end
   lcon = vcat(-T(0.55), zeros(T, 8))
   ucon = vcat(T(0.55), T(Inf), T(Inf), zeros(T, 6))
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs109"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs109", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs112.jl
+++ b/src/ADNLPProblems/hs112.jl
@@ -19,5 +19,5 @@ function hs112(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   end
   lcon = T[2, 1, 1]
   ucon = T[2, 1, 1]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs112"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs112", lin = [1, 2, 3]; kwargs...)
 end

--- a/src/ADNLPProblems/hs113.jl
+++ b/src/ADNLPProblems/hs113.jl
@@ -30,5 +30,5 @@ function hs113(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   end
   lcon = vcat(-105, 0, -12, zeros(T, 5))
   ucon = T(Inf) * ones(T, 8)
-  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs113"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs113", lin = [1, 2, 3]; kwargs...)
 end

--- a/src/ADNLPProblems/hs114.jl
+++ b/src/ADNLPProblems/hs114.jl
@@ -32,5 +32,5 @@ function hs114(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   end
   lcon = vcat(0, -T(35.82), 133, T(35.82), -133, zeros(T, 6))
   ucon = vcat(zero(T), T(Inf) * ones(T, 8), zeros(T, 2))
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs114"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs114", lin = [1, 2, 3, 4, 5]; kwargs...)
 end

--- a/src/ADNLPProblems/hs116.jl
+++ b/src/ADNLPProblems/hs116.jl
@@ -36,5 +36,5 @@ function hs116(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   end
   lcon = vcat(zeros(T, 2), -1, 50, -T(Inf), zeros(T, 10))
   ucon = vcat(T(Inf) * ones(T, 4), 250, T(Inf) * ones(T, 10))
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs116"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs116", lin = [1, 2, 3, 4, 5]; kwargs...)
 end

--- a/src/ADNLPProblems/hs118.jl
+++ b/src/ADNLPProblems/hs118.jl
@@ -38,5 +38,5 @@ function hs118(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
   end
   lcon = T[60, 70, 100, 50, 85, -7, -7, -7, -7, -7, -7, -7, -7, -7, -7, -7, -7]
   ucon = vcat(T(Inf) * ones(T, 5), T[6, 6, 7, 6, 6, 7, 6, 6, 7, 6, 6, 7])
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs118"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs118", lin = 1:17; kwargs...)
 end

--- a/src/ADNLPProblems/hs119.jl
+++ b/src/ADNLPProblems/hs119.jl
@@ -68,5 +68,5 @@ function hs119(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
     36.8,
     -24,
   ]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs119"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs119", lin = 1:8; kwargs...)
 end

--- a/src/ADNLPProblems/hs14.jl
+++ b/src/ADNLPProblems/hs14.jl
@@ -7,5 +7,5 @@ function hs14(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   lcon = T[-1; -Inf]
   ucon = T[-1; 0]
 
-  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs14"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs14", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs21.jl
+++ b/src/ADNLPProblems/hs21.jl
@@ -14,5 +14,5 @@ function hs21(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = 10 * ones(T, 1)
   ucon = T(Inf) * ones(T, 1)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs21"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs21", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs22.jl
+++ b/src/ADNLPProblems/hs22.jl
@@ -12,5 +12,5 @@ function hs22(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = [-T(Inf), zero(T)]
   ucon = [2, T(Inf)]
-  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs22"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, c, lcon, ucon, name = "hs22", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs23.jl
+++ b/src/ADNLPProblems/hs23.jl
@@ -14,5 +14,5 @@ function hs23(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = vcat(one(T), zeros(T, 4))
   ucon = T(Inf) * ones(T, 5)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs23"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs23", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs24.jl
+++ b/src/ADNLPProblems/hs24.jl
@@ -14,5 +14,5 @@ function hs24(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = zeros(T, 2)
   ucon = T[Inf, 6]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs24"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs24", lin = [1, 2]; kwargs...)
 end

--- a/src/ADNLPProblems/hs28.jl
+++ b/src/ADNLPProblems/hs28.jl
@@ -7,7 +7,8 @@ function hs28(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
     x -> [x[1] + 2 * x[2] + 3 * x[3]],
     ones(T, 1),
     ones(T, 1),
-    name = "hs28";
+    name = "hs28",
+    lin = [1];
     kwargs...,
   )
 end

--- a/src/ADNLPProblems/hs32.jl
+++ b/src/ADNLPProblems/hs32.jl
@@ -14,5 +14,5 @@ function hs32(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = T[1, 0]
   ucon = T[1, Inf]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs32"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs32", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs35.jl
+++ b/src/ADNLPProblems/hs35.jl
@@ -19,5 +19,5 @@ function hs35(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = -T(Inf) * ones(T, 1)
   ucon = T[3]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs35"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs35", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs36.jl
+++ b/src/ADNLPProblems/hs36.jl
@@ -14,5 +14,5 @@ function hs36(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = [-T(Inf)]
   ucon = T[72]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs36"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs36", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs37.jl
+++ b/src/ADNLPProblems/hs37.jl
@@ -14,5 +14,5 @@ function hs37(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = zeros(T, 1)
   ucon = T[72]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs37"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs37", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs41.jl
+++ b/src/ADNLPProblems/hs41.jl
@@ -14,5 +14,5 @@ function hs41(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = zeros(T, 1)
   ucon = zeros(T, 1)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs41"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs41", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs42.jl
+++ b/src/ADNLPProblems/hs42.jl
@@ -7,7 +7,8 @@ function hs42(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
     x -> [x[1]; x[3]^2 + x[4]^2 - 2],
     T[2, 0],
     T[2, 0],
-    name = "hs42";
+    name = "hs42",
+    lin = [1];
     kwargs...,
   )
 end

--- a/src/ADNLPProblems/hs44.jl
+++ b/src/ADNLPProblems/hs44.jl
@@ -21,5 +21,5 @@ function hs44(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = -T(Inf) * ones(T, 6)
   ucon = T[8, 12, 12, 8, 8, 5]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs44"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs44", lin = 1:6; kwargs...)
 end

--- a/src/ADNLPProblems/hs48.jl
+++ b/src/ADNLPProblems/hs48.jl
@@ -7,7 +7,8 @@ function hs48(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
     x -> [x[1] + x[2] + x[3] + x[4] + x[5]; x[3] - 2 * (x[4] + x[5])],
     T[5, -3],
     T[5, -3],
-    name = "hs48";
+    name = "hs48",
+    lin = [1, 2];
     kwargs...,
   )
 end

--- a/src/ADNLPProblems/hs49.jl
+++ b/src/ADNLPProblems/hs49.jl
@@ -7,7 +7,8 @@ function hs49(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
     x -> [x[1] + x[2] + x[3] + 4 * x[4]; x[3] + 5 * x[5]],
     T[7, 6],
     T[7, 6],
-    name = "hs49";
+    name = "hs49",
+    lin = [1, 2];
     kwargs...,
   )
 end

--- a/src/ADNLPProblems/hs50.jl
+++ b/src/ADNLPProblems/hs50.jl
@@ -11,7 +11,8 @@ function hs50(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
     ],
     6 * ones(T, 3),
     6 * ones(T, 3),
-    name = "hs50";
+    name = "hs50",
+    lin = 1:3;
     kwargs...,
   )
 end

--- a/src/ADNLPProblems/hs51.jl
+++ b/src/ADNLPProblems/hs51.jl
@@ -7,7 +7,8 @@ function hs51(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
     x -> [x[1] + 3 * x[2]; x[3] + x[4] - 2 * x[5]; x[2] - x[5]],
     T[4, 0, 0],
     T[4, 0, 0],
-    name = "hs51";
+    name = "hs51",
+    lin = 1:3;
     kwargs...,
   )
 end

--- a/src/ADNLPProblems/hs52.jl
+++ b/src/ADNLPProblems/hs52.jl
@@ -7,7 +7,8 @@ function hs52(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
     x -> [x[1] + 3 * x[2]; x[3] + x[4] - 2 * x[5]; x[2] - x[5]],
     zeros(T, 3),
     zeros(T, 3),
-    name = "hs52";
+    name = "hs52",
+    lin = 1:3;
     kwargs...,
   )
 end

--- a/src/ADNLPProblems/hs53.jl
+++ b/src/ADNLPProblems/hs53.jl
@@ -14,5 +14,5 @@ function hs53(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = zeros(T, 3)
   ucon = zeros(T, 3)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs53"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs53", lin = 1:3; kwargs...)
 end

--- a/src/ADNLPProblems/hs54.jl
+++ b/src/ADNLPProblems/hs54.jl
@@ -23,5 +23,5 @@ function hs54(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = zeros(T, 1)
   ucon = zeros(T, 1)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs54"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs54", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs55.jl
+++ b/src/ADNLPProblems/hs55.jl
@@ -21,5 +21,5 @@ function hs55(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = T[6, 3, 2, 1, 2, 2]
   ucon = T[6, 3, 2, 1, 2, 2]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs55"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs55", lin = 1:6; kwargs...)
 end

--- a/src/ADNLPProblems/hs62.jl
+++ b/src/ADNLPProblems/hs62.jl
@@ -18,5 +18,5 @@ function hs62(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = ones(T, 1)
   ucon = ones(T, 1)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs62"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs62", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs63.jl
+++ b/src/ADNLPProblems/hs63.jl
@@ -9,7 +9,8 @@ function hs63(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
     x -> [8 * x[1] + 14 * x[2] + 7 * x[3]; x[1]^2 + x[2]^2 + x[3]^2 - 25],
     T[56, 0],
     T[56, 0],
-    name = "hs63";
+    name = "hs63",
+    lin = [1];
     kwargs...,
   )
 end

--- a/src/ADNLPProblems/hs73.jl
+++ b/src/ADNLPProblems/hs73.jl
@@ -19,5 +19,5 @@ function hs73(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = T[1, 5, 0]
   ucon = vcat(one(T), T(Inf), T(Inf))
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs73"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs73", lin = [1, 2]; kwargs...)
 end

--- a/src/ADNLPProblems/hs74.jl
+++ b/src/ADNLPProblems/hs74.jl
@@ -20,5 +20,5 @@ function hs74(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = vcat(-a, zeros(T, 3))
   ucon = vcat(a, zeros(T, 3))
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs74"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs74", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs75.jl
+++ b/src/ADNLPProblems/hs75.jl
@@ -20,5 +20,5 @@ function hs75(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = vcat(-a, zeros(T, 3))
   ucon = vcat(a, zeros(T, 3))
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs75"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs75", lin = [1]; kwargs...)
 end

--- a/src/ADNLPProblems/hs76.jl
+++ b/src/ADNLPProblems/hs76.jl
@@ -15,5 +15,5 @@ function hs76(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = T[1.5, -Inf, -Inf]
   ucon = T[Inf, 5, 4]
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs76"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs76", lin = 1:3; kwargs...)
 end

--- a/src/ADNLPProblems/hs86.jl
+++ b/src/ADNLPProblems/hs86.jl
@@ -40,5 +40,5 @@ function hs86(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) w
   end
   lcon = T[-40, -2, -0.25, -4, -4, -1, -40, -60, 5, 1]
   ucon = T(Inf) * ones(T, 10)
-  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs86"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, name = "hs86", lin = 1:10; kwargs...)
 end

--- a/src/ADNLPProblems/hs9.jl
+++ b/src/ADNLPProblems/hs9.jl
@@ -7,7 +7,8 @@ function hs9(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) wh
     x -> [4 * x[1] - 3 * x[2]],
     zeros(T, 1),
     zeros(T, 1),
-    name = "hs9";
+    name = "hs9",
+    lin = [1];
     kwargs...,
   )
 end

--- a/src/Meta/hs105.jl
+++ b/src/Meta/hs105.jl
@@ -19,7 +19,7 @@ hs105_meta = Dict(
 )
 get_hs105_nvar(; n::Integer = default_nvar, kwargs...) = 8
 get_hs105_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs105_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs105_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs105_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs105_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs105_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs105_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs106.jl
+++ b/src/Meta/hs106.jl
@@ -19,7 +19,7 @@ hs106_meta = Dict(
 )
 get_hs106_nvar(; n::Integer = default_nvar, kwargs...) = 8
 get_hs106_ncon(; n::Integer = default_nvar, kwargs...) = 6
-get_hs106_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs106_nnln(; n::Integer = default_nvar, kwargs...) = 6
+get_hs106_nlin(; n::Integer = default_nvar, kwargs...) = 3
+get_hs106_nnln(; n::Integer = default_nvar, kwargs...) = 3
 get_hs106_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs106_nineq(; n::Integer = default_nvar, kwargs...) = 6

--- a/src/Meta/hs109.jl
+++ b/src/Meta/hs109.jl
@@ -19,7 +19,7 @@ hs109_meta = Dict(
 )
 get_hs109_nvar(; n::Integer = default_nvar, kwargs...) = 9
 get_hs109_ncon(; n::Integer = default_nvar, kwargs...) = 9
-get_hs109_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs109_nnln(; n::Integer = default_nvar, kwargs...) = 9
+get_hs109_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs109_nnln(; n::Integer = default_nvar, kwargs...) = 8
 get_hs109_nequ(; n::Integer = default_nvar, kwargs...) = 6
 get_hs109_nineq(; n::Integer = default_nvar, kwargs...) = 3

--- a/src/Meta/hs112.jl
+++ b/src/Meta/hs112.jl
@@ -19,7 +19,7 @@ hs112_meta = Dict(
 )
 get_hs112_nvar(; n::Integer = default_nvar, kwargs...) = 10
 get_hs112_ncon(; n::Integer = default_nvar, kwargs...) = 3
-get_hs112_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs112_nnln(; n::Integer = default_nvar, kwargs...) = 3
+get_hs112_nlin(; n::Integer = default_nvar, kwargs...) = 3
+get_hs112_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs112_nequ(; n::Integer = default_nvar, kwargs...) = 3
 get_hs112_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs113.jl
+++ b/src/Meta/hs113.jl
@@ -19,7 +19,7 @@ hs113_meta = Dict(
 )
 get_hs113_nvar(; n::Integer = default_nvar, kwargs...) = 10
 get_hs113_ncon(; n::Integer = default_nvar, kwargs...) = 8
-get_hs113_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs113_nnln(; n::Integer = default_nvar, kwargs...) = 8
+get_hs113_nlin(; n::Integer = default_nvar, kwargs...) = 3
+get_hs113_nnln(; n::Integer = default_nvar, kwargs...) = 5
 get_hs113_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs113_nineq(; n::Integer = default_nvar, kwargs...) = 8

--- a/src/Meta/hs114.jl
+++ b/src/Meta/hs114.jl
@@ -19,7 +19,7 @@ hs114_meta = Dict(
 )
 get_hs114_nvar(; n::Integer = default_nvar, kwargs...) = 10
 get_hs114_ncon(; n::Integer = default_nvar, kwargs...) = 11
-get_hs114_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs114_nnln(; n::Integer = default_nvar, kwargs...) = 11
+get_hs114_nlin(; n::Integer = default_nvar, kwargs...) = 5
+get_hs114_nnln(; n::Integer = default_nvar, kwargs...) = 6
 get_hs114_nequ(; n::Integer = default_nvar, kwargs...) = 3
 get_hs114_nineq(; n::Integer = default_nvar, kwargs...) = 8

--- a/src/Meta/hs116.jl
+++ b/src/Meta/hs116.jl
@@ -19,7 +19,7 @@ hs116_meta = Dict(
 )
 get_hs116_nvar(; n::Integer = default_nvar, kwargs...) = 13
 get_hs116_ncon(; n::Integer = default_nvar, kwargs...) = 15
-get_hs116_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs116_nnln(; n::Integer = default_nvar, kwargs...) = 15
+get_hs116_nlin(; n::Integer = default_nvar, kwargs...) = 5
+get_hs116_nnln(; n::Integer = default_nvar, kwargs...) = 10
 get_hs116_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs116_nineq(; n::Integer = default_nvar, kwargs...) = 15

--- a/src/Meta/hs118.jl
+++ b/src/Meta/hs118.jl
@@ -19,7 +19,7 @@ hs118_meta = Dict(
 )
 get_hs118_nvar(; n::Integer = default_nvar, kwargs...) = 15
 get_hs118_ncon(; n::Integer = default_nvar, kwargs...) = 17
-get_hs118_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs118_nnln(; n::Integer = default_nvar, kwargs...) = 17
+get_hs118_nlin(; n::Integer = default_nvar, kwargs...) = 17
+get_hs118_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs118_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs118_nineq(; n::Integer = default_nvar, kwargs...) = 17

--- a/src/Meta/hs119.jl
+++ b/src/Meta/hs119.jl
@@ -19,7 +19,7 @@ hs119_meta = Dict(
 )
 get_hs119_nvar(; n::Integer = default_nvar, kwargs...) = 16
 get_hs119_ncon(; n::Integer = default_nvar, kwargs...) = 8
-get_hs119_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs119_nnln(; n::Integer = default_nvar, kwargs...) = 8
+get_hs119_nlin(; n::Integer = default_nvar, kwargs...) = 8
+get_hs119_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs119_nequ(; n::Integer = default_nvar, kwargs...) = 8
 get_hs119_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs14.jl
+++ b/src/Meta/hs14.jl
@@ -19,7 +19,7 @@ hs14_meta = Dict(
 )
 get_hs14_nvar(; n::Integer = default_nvar, kwargs...) = 2
 get_hs14_ncon(; n::Integer = default_nvar, kwargs...) = 2
-get_hs14_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs14_nnln(; n::Integer = default_nvar, kwargs...) = 2
+get_hs14_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs14_nnln(; n::Integer = default_nvar, kwargs...) = 1
 get_hs14_nequ(; n::Integer = default_nvar, kwargs...) = 1
 get_hs14_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs21.jl
+++ b/src/Meta/hs21.jl
@@ -19,7 +19,7 @@ hs21_meta = Dict(
 )
 get_hs21_nvar(; n::Integer = default_nvar, kwargs...) = 2
 get_hs21_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs21_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs21_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs21_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs21_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs21_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs21_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs22.jl
+++ b/src/Meta/hs22.jl
@@ -19,7 +19,7 @@ hs22_meta = Dict(
 )
 get_hs22_nvar(; n::Integer = default_nvar, kwargs...) = 2
 get_hs22_ncon(; n::Integer = default_nvar, kwargs...) = 2
-get_hs22_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs22_nnln(; n::Integer = default_nvar, kwargs...) = 2
+get_hs22_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs22_nnln(; n::Integer = default_nvar, kwargs...) = 1
 get_hs22_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs22_nineq(; n::Integer = default_nvar, kwargs...) = 2

--- a/src/Meta/hs23.jl
+++ b/src/Meta/hs23.jl
@@ -19,7 +19,7 @@ hs23_meta = Dict(
 )
 get_hs23_nvar(; n::Integer = default_nvar, kwargs...) = 2
 get_hs23_ncon(; n::Integer = default_nvar, kwargs...) = 5
-get_hs23_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs23_nnln(; n::Integer = default_nvar, kwargs...) = 5
+get_hs23_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs23_nnln(; n::Integer = default_nvar, kwargs...) = 4
 get_hs23_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs23_nineq(; n::Integer = default_nvar, kwargs...) = 5

--- a/src/Meta/hs24.jl
+++ b/src/Meta/hs24.jl
@@ -19,7 +19,7 @@ hs24_meta = Dict(
 )
 get_hs24_nvar(; n::Integer = default_nvar, kwargs...) = 2
 get_hs24_ncon(; n::Integer = default_nvar, kwargs...) = 2
-get_hs24_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs24_nnln(; n::Integer = default_nvar, kwargs...) = 2
+get_hs24_nlin(; n::Integer = default_nvar, kwargs...) = 2
+get_hs24_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs24_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs24_nineq(; n::Integer = default_nvar, kwargs...) = 2

--- a/src/Meta/hs28.jl
+++ b/src/Meta/hs28.jl
@@ -19,7 +19,7 @@ hs28_meta = Dict(
 )
 get_hs28_nvar(; n::Integer = default_nvar, kwargs...) = 3
 get_hs28_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs28_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs28_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs28_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs28_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs28_nequ(; n::Integer = default_nvar, kwargs...) = 1
 get_hs28_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs32.jl
+++ b/src/Meta/hs32.jl
@@ -19,7 +19,7 @@ hs32_meta = Dict(
 )
 get_hs32_nvar(; n::Integer = default_nvar, kwargs...) = 3
 get_hs32_ncon(; n::Integer = default_nvar, kwargs...) = 2
-get_hs32_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs32_nnln(; n::Integer = default_nvar, kwargs...) = 2
+get_hs32_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs32_nnln(; n::Integer = default_nvar, kwargs...) = 1
 get_hs32_nequ(; n::Integer = default_nvar, kwargs...) = 1
 get_hs32_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs35.jl
+++ b/src/Meta/hs35.jl
@@ -19,7 +19,7 @@ hs35_meta = Dict(
 )
 get_hs35_nvar(; n::Integer = default_nvar, kwargs...) = 3
 get_hs35_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs35_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs35_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs35_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs35_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs35_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs35_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs36.jl
+++ b/src/Meta/hs36.jl
@@ -19,7 +19,7 @@ hs36_meta = Dict(
 )
 get_hs36_nvar(; n::Integer = default_nvar, kwargs...) = 3
 get_hs36_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs36_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs36_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs36_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs36_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs36_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs36_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs37.jl
+++ b/src/Meta/hs37.jl
@@ -19,7 +19,7 @@ hs37_meta = Dict(
 )
 get_hs37_nvar(; n::Integer = default_nvar, kwargs...) = 3
 get_hs37_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs37_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs37_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs37_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs37_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs37_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs37_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs41.jl
+++ b/src/Meta/hs41.jl
@@ -19,7 +19,7 @@ hs41_meta = Dict(
 )
 get_hs41_nvar(; n::Integer = default_nvar, kwargs...) = 4
 get_hs41_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs41_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs41_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs41_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs41_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs41_nequ(; n::Integer = default_nvar, kwargs...) = 1
 get_hs41_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs42.jl
+++ b/src/Meta/hs42.jl
@@ -19,7 +19,7 @@ hs42_meta = Dict(
 )
 get_hs42_nvar(; n::Integer = default_nvar, kwargs...) = 4
 get_hs42_ncon(; n::Integer = default_nvar, kwargs...) = 2
-get_hs42_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs42_nnln(; n::Integer = default_nvar, kwargs...) = 2
+get_hs42_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs42_nnln(; n::Integer = default_nvar, kwargs...) = 1
 get_hs42_nequ(; n::Integer = default_nvar, kwargs...) = 2
 get_hs42_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs44.jl
+++ b/src/Meta/hs44.jl
@@ -19,7 +19,7 @@ hs44_meta = Dict(
 )
 get_hs44_nvar(; n::Integer = default_nvar, kwargs...) = 4
 get_hs44_ncon(; n::Integer = default_nvar, kwargs...) = 6
-get_hs44_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs44_nnln(; n::Integer = default_nvar, kwargs...) = 6
+get_hs44_nlin(; n::Integer = default_nvar, kwargs...) = 6
+get_hs44_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs44_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs44_nineq(; n::Integer = default_nvar, kwargs...) = 6

--- a/src/Meta/hs48.jl
+++ b/src/Meta/hs48.jl
@@ -19,7 +19,7 @@ hs48_meta = Dict(
 )
 get_hs48_nvar(; n::Integer = default_nvar, kwargs...) = 5
 get_hs48_ncon(; n::Integer = default_nvar, kwargs...) = 2
-get_hs48_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs48_nnln(; n::Integer = default_nvar, kwargs...) = 2
+get_hs48_nlin(; n::Integer = default_nvar, kwargs...) = 2
+get_hs48_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs48_nequ(; n::Integer = default_nvar, kwargs...) = 2
 get_hs48_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs49.jl
+++ b/src/Meta/hs49.jl
@@ -19,7 +19,7 @@ hs49_meta = Dict(
 )
 get_hs49_nvar(; n::Integer = default_nvar, kwargs...) = 5
 get_hs49_ncon(; n::Integer = default_nvar, kwargs...) = 2
-get_hs49_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs49_nnln(; n::Integer = default_nvar, kwargs...) = 2
+get_hs49_nlin(; n::Integer = default_nvar, kwargs...) = 2
+get_hs49_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs49_nequ(; n::Integer = default_nvar, kwargs...) = 2
 get_hs49_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs50.jl
+++ b/src/Meta/hs50.jl
@@ -19,7 +19,7 @@ hs50_meta = Dict(
 )
 get_hs50_nvar(; n::Integer = default_nvar, kwargs...) = 5
 get_hs50_ncon(; n::Integer = default_nvar, kwargs...) = 3
-get_hs50_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs50_nnln(; n::Integer = default_nvar, kwargs...) = 3
+get_hs50_nlin(; n::Integer = default_nvar, kwargs...) = 3
+get_hs50_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs50_nequ(; n::Integer = default_nvar, kwargs...) = 3
 get_hs50_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs51.jl
+++ b/src/Meta/hs51.jl
@@ -19,7 +19,7 @@ hs51_meta = Dict(
 )
 get_hs51_nvar(; n::Integer = default_nvar, kwargs...) = 5
 get_hs51_ncon(; n::Integer = default_nvar, kwargs...) = 3
-get_hs51_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs51_nnln(; n::Integer = default_nvar, kwargs...) = 3
+get_hs51_nlin(; n::Integer = default_nvar, kwargs...) = 3
+get_hs51_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs51_nequ(; n::Integer = default_nvar, kwargs...) = 3
 get_hs51_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs52.jl
+++ b/src/Meta/hs52.jl
@@ -19,7 +19,7 @@ hs52_meta = Dict(
 )
 get_hs52_nvar(; n::Integer = default_nvar, kwargs...) = 5
 get_hs52_ncon(; n::Integer = default_nvar, kwargs...) = 3
-get_hs52_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs52_nnln(; n::Integer = default_nvar, kwargs...) = 3
+get_hs52_nlin(; n::Integer = default_nvar, kwargs...) = 3
+get_hs52_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs52_nequ(; n::Integer = default_nvar, kwargs...) = 3
 get_hs52_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs53.jl
+++ b/src/Meta/hs53.jl
@@ -19,7 +19,7 @@ hs53_meta = Dict(
 )
 get_hs53_nvar(; n::Integer = default_nvar, kwargs...) = 5
 get_hs53_ncon(; n::Integer = default_nvar, kwargs...) = 3
-get_hs53_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs53_nnln(; n::Integer = default_nvar, kwargs...) = 3
+get_hs53_nlin(; n::Integer = default_nvar, kwargs...) = 3
+get_hs53_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs53_nequ(; n::Integer = default_nvar, kwargs...) = 3
 get_hs53_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs54.jl
+++ b/src/Meta/hs54.jl
@@ -19,7 +19,7 @@ hs54_meta = Dict(
 )
 get_hs54_nvar(; n::Integer = default_nvar, kwargs...) = 6
 get_hs54_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs54_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs54_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs54_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs54_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs54_nequ(; n::Integer = default_nvar, kwargs...) = 1
 get_hs54_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs55.jl
+++ b/src/Meta/hs55.jl
@@ -19,7 +19,7 @@ hs55_meta = Dict(
 )
 get_hs55_nvar(; n::Integer = default_nvar, kwargs...) = 6
 get_hs55_ncon(; n::Integer = default_nvar, kwargs...) = 6
-get_hs55_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs55_nnln(; n::Integer = default_nvar, kwargs...) = 6
+get_hs55_nlin(; n::Integer = default_nvar, kwargs...) = 6
+get_hs55_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs55_nequ(; n::Integer = default_nvar, kwargs...) = 6
 get_hs55_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs62.jl
+++ b/src/Meta/hs62.jl
@@ -19,7 +19,7 @@ hs62_meta = Dict(
 )
 get_hs62_nvar(; n::Integer = default_nvar, kwargs...) = 3
 get_hs62_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs62_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs62_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs62_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs62_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs62_nequ(; n::Integer = default_nvar, kwargs...) = 1
 get_hs62_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs63.jl
+++ b/src/Meta/hs63.jl
@@ -19,7 +19,7 @@ hs63_meta = Dict(
 )
 get_hs63_nvar(; n::Integer = default_nvar, kwargs...) = 3
 get_hs63_ncon(; n::Integer = default_nvar, kwargs...) = 2
-get_hs63_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs63_nnln(; n::Integer = default_nvar, kwargs...) = 2
+get_hs63_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs63_nnln(; n::Integer = default_nvar, kwargs...) = 1
 get_hs63_nequ(; n::Integer = default_nvar, kwargs...) = 2
 get_hs63_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/hs73.jl
+++ b/src/Meta/hs73.jl
@@ -19,7 +19,7 @@ hs73_meta = Dict(
 )
 get_hs73_nvar(; n::Integer = default_nvar, kwargs...) = 4
 get_hs73_ncon(; n::Integer = default_nvar, kwargs...) = 3
-get_hs73_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs73_nnln(; n::Integer = default_nvar, kwargs...) = 3
+get_hs73_nlin(; n::Integer = default_nvar, kwargs...) = 2
+get_hs73_nnln(; n::Integer = default_nvar, kwargs...) = 1
 get_hs73_nequ(; n::Integer = default_nvar, kwargs...) = 1
 get_hs73_nineq(; n::Integer = default_nvar, kwargs...) = 2

--- a/src/Meta/hs74.jl
+++ b/src/Meta/hs74.jl
@@ -19,7 +19,7 @@ hs74_meta = Dict(
 )
 get_hs74_nvar(; n::Integer = default_nvar, kwargs...) = 4
 get_hs74_ncon(; n::Integer = default_nvar, kwargs...) = 4
-get_hs74_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs74_nnln(; n::Integer = default_nvar, kwargs...) = 4
+get_hs74_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs74_nnln(; n::Integer = default_nvar, kwargs...) = 3
 get_hs74_nequ(; n::Integer = default_nvar, kwargs...) = 3
 get_hs74_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs75.jl
+++ b/src/Meta/hs75.jl
@@ -19,7 +19,7 @@ hs75_meta = Dict(
 )
 get_hs75_nvar(; n::Integer = default_nvar, kwargs...) = 4
 get_hs75_ncon(; n::Integer = default_nvar, kwargs...) = 4
-get_hs75_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs75_nnln(; n::Integer = default_nvar, kwargs...) = 4
+get_hs75_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs75_nnln(; n::Integer = default_nvar, kwargs...) = 3
 get_hs75_nequ(; n::Integer = default_nvar, kwargs...) = 3
 get_hs75_nineq(; n::Integer = default_nvar, kwargs...) = 1

--- a/src/Meta/hs76.jl
+++ b/src/Meta/hs76.jl
@@ -19,7 +19,7 @@ hs76_meta = Dict(
 )
 get_hs76_nvar(; n::Integer = default_nvar, kwargs...) = 4
 get_hs76_ncon(; n::Integer = default_nvar, kwargs...) = 3
-get_hs76_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs76_nnln(; n::Integer = default_nvar, kwargs...) = 3
+get_hs76_nlin(; n::Integer = default_nvar, kwargs...) = 3
+get_hs76_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs76_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs76_nineq(; n::Integer = default_nvar, kwargs...) = 3

--- a/src/Meta/hs86.jl
+++ b/src/Meta/hs86.jl
@@ -19,7 +19,7 @@ hs86_meta = Dict(
 )
 get_hs86_nvar(; n::Integer = default_nvar, kwargs...) = 5
 get_hs86_ncon(; n::Integer = default_nvar, kwargs...) = 10
-get_hs86_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs86_nnln(; n::Integer = default_nvar, kwargs...) = 10
+get_hs86_nlin(; n::Integer = default_nvar, kwargs...) = 10
+get_hs86_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs86_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_hs86_nineq(; n::Integer = default_nvar, kwargs...) = 10

--- a/src/Meta/hs9.jl
+++ b/src/Meta/hs9.jl
@@ -19,7 +19,7 @@ hs9_meta = Dict(
 )
 get_hs9_nvar(; n::Integer = default_nvar, kwargs...) = 2
 get_hs9_ncon(; n::Integer = default_nvar, kwargs...) = 1
-get_hs9_nlin(; n::Integer = default_nvar, kwargs...) = 0
-get_hs9_nnln(; n::Integer = default_nvar, kwargs...) = 1
+get_hs9_nlin(; n::Integer = default_nvar, kwargs...) = 1
+get_hs9_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_hs9_nequ(; n::Integer = default_nvar, kwargs...) = 1
 get_hs9_nineq(; n::Integer = default_nvar, kwargs...) = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,7 @@ for prob in names(PureJuMP)
     @test nlp_ad.meta.ucon == nlp_jump.meta.ucon
     @test isapprox(cons(nlp_ad, x1), cons(nlp_jump, x1))
     @test isapprox(cons(nlp_ad, x2), cons(nlp_jump, x2))
+    @test nlp_jump.meta.lin == nlp_ad.meta.lin
   end
 
   meta_sanity_check(prob, nlp_ad)


### PR DESCRIPTION
#96 

The following piece of code was useful to detect the problems.
```
using ADNLPModels
using OptimizationProblems, NLPModelsJuMP
for prob in setdiff(names(OptimizationProblems.PureJuMP), [:PureJuMP]) 
  model = MathOptNLPModel(OptimizationProblems.PureJuMP.eval(prob)())
  nlp = OptimizationProblems.ADNLPProblems.eval(prob)()
  if model.meta.lin != nlp.meta.lin
    @show prob, model.meta.ncon, model.meta.nlin, nlp.meta.ncon, nlp.meta.nlin
  end
end
```