### PR TITLE
Set min `n` value instead of error

### DIFF
--- a/src/ADNLPProblems/arwhead.jl
+++ b/src/ADNLPProblems/arwhead.jl
@@ -1,6 +1,8 @@
 export arwhead
 
 function arwhead(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("arwhead: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum((x[i]^2 + x[n]^2)^2 - 4 * x[i] + 3 for i = 1:(n - 1))

--- a/src/ADNLPProblems/bdqrtic.jl
+++ b/src/ADNLPProblems/bdqrtic.jl
@@ -1,7 +1,8 @@
 export bdqrtic
 
 function bdqrtic(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 5 || error("bdqrtic : n ≥ 5")
+  n < 5 && @warn("bdqrtic: number of variables must be ≥ 5")
+  n = max(5, n)
   function f(x)
     n = length(x)
     return sum(

--- a/src/ADNLPProblems/broydn7d.jl
+++ b/src/ADNLPProblems/broydn7d.jl
@@ -1,8 +1,9 @@
 export broydn7d
 
 function broydn7d(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  mod(n, 2) > 0 && @warn("broydn7d: number of variables adjusted to be even")
   n2 = max(1, div(n, 2))
-  n = 2 * n2  # number of variables adjusted to be even
+  n = 2 * n2
   function f(x)
     n = length(x)
     p = T(7 / 3)

--- a/src/ADNLPProblems/chainwoo.jl
+++ b/src/ADNLPProblems/chainwoo.jl
@@ -1,7 +1,8 @@
 export chainwoo
 
 function chainwoo(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n = 4 * max(1, div(n, 4))  # number of variables adjusted to be a multiple of 4
+  (n % 4 == 0) || @warn("chainwoo: number of variables adjusted to be a multiple of 4")
+  n = 4 * max(1, div(n, 4))
   function f(x)
     n = length(x)
     return 1 + sum(

--- a/src/ADNLPProblems/chnrosnb_mod.jl
+++ b/src/ADNLPProblems/chnrosnb_mod.jl
@@ -1,7 +1,8 @@
 export chnrosnb_mod
 
 function chnrosnb_mod(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || ("chnrosnb : n ≥ 2")
+  n < 2 && @warn("chnrosnb: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return 16 * sum((x[i - 1] - x[i]^2)^2 * T(1.5 + sin(i))^2 for i = 2:n) +

--- a/src/ADNLPProblems/cosine.jl
+++ b/src/ADNLPProblems/cosine.jl
@@ -1,6 +1,8 @@
 export cosine
 
 function cosine(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("cosine: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum(cos(x[i]^2 - x[i + 1] / 2) for i = 1:(n - 1))

--- a/src/ADNLPProblems/cragglvy.jl
+++ b/src/ADNLPProblems/cragglvy.jl
@@ -1,7 +1,8 @@
 export cragglvy
 
 function cragglvy(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("cragglvy : n ≥ 2")
+  n < 2 && @warn("cragglvy: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum(

--- a/src/ADNLPProblems/edensch.jl
+++ b/src/ADNLPProblems/edensch.jl
@@ -1,6 +1,8 @@
 export edensch
 
 function edensch(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("edensch: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return 16 + sum(

--- a/src/ADNLPProblems/eg2.jl
+++ b/src/ADNLPProblems/eg2.jl
@@ -1,6 +1,8 @@
 export eg2
 
 function eg2(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("eg2: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     sum(sin(x[1] + x[i]^2 - 1) for i = 1:(n - 1)) + sin(x[n]^2) / 2

--- a/src/ADNLPProblems/engval1.jl
+++ b/src/ADNLPProblems/engval1.jl
@@ -1,7 +1,8 @@
 export engval1
 
 function engval1(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("engval : n ≥ 2")
+  n < 2 && @warn("engval1: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum((x[i]^2 + x[i + 1]^2)^2 - 4 * x[i] + 3 for i = 1:(n - 1))

--- a/src/ADNLPProblems/errinros_mod.jl
+++ b/src/ADNLPProblems/errinros_mod.jl
@@ -1,7 +1,8 @@
 export errinros_mod
 
 function errinros_mod(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("errinros : n ≥ 2")
+  n < 2 && @warn("errinros_mod: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum((x[i - 1] - 16 * x[i]^2 * T(1.5 + sin(i))^2)^2 for i = 2:n) +

--- a/src/ADNLPProblems/extrosnb.jl
+++ b/src/ADNLPProblems/extrosnb.jl
@@ -1,6 +1,8 @@
 export extrosnb
 
 function extrosnb(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("extrosnb: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return 100 * sum((x[i] - x[i - 1]^2)^2 for i = 2:n) + (1 - x[1])^2

--- a/src/ADNLPProblems/fletcbv2.jl
+++ b/src/ADNLPProblems/fletcbv2.jl
@@ -1,7 +1,8 @@
 export fletcbv2
 
 function fletcbv2(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("fletcbv2 : n ≥ 2")
+  n < 2 && @warn("fletchbv2: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     h = T(1 / (n + 1))

--- a/src/ADNLPProblems/fletcbv3_mod.jl
+++ b/src/ADNLPProblems/fletcbv3_mod.jl
@@ -1,7 +1,8 @@
 export fletcbv3_mod
 
 function fletcbv3_mod(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("fletcbv3 : n ≥ 2")
+  n < 2 && @warn("fletchbv3_mod: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     p = T(10.0^(-8))

--- a/src/ADNLPProblems/fletchcr.jl
+++ b/src/ADNLPProblems/fletchcr.jl
@@ -1,6 +1,8 @@
 export fletchcr
 
 function fletchcr(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("fletchcr: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return 100 * sum((x[i + 1] - x[i] + 1 - x[i]^2)^2 for i = 1:(n - 1))

--- a/src/ADNLPProblems/freuroth.jl
+++ b/src/ADNLPProblems/freuroth.jl
@@ -1,6 +1,8 @@
 export freuroth
 
 function freuroth(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("freuroth: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum(((5 - x[i + 1]) * x[i + 1]^2 + x[i] - 2 * x[i + 1] - 13)^2 for i = 1:(n - 1)) +

--- a/src/ADNLPProblems/genrose.jl
+++ b/src/ADNLPProblems/genrose.jl
@@ -1,6 +1,8 @@
 export genrose, rosenbrock
 
 function genrose(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("genrose: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return 1 +

--- a/src/ADNLPProblems/genrose_nash.jl
+++ b/src/ADNLPProblems/genrose_nash.jl
@@ -1,7 +1,8 @@
 export genrose_nash
 
 function genrose_nash(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("genrose_nash : n ≥ 2")
+  n < 2 && @warn("genrose_nash: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return 1 + 100 * sum((x[i] - x[i - 1]^2)^2 for i = 2:n) + sum((1 - x[i])^2 for i = 2:n)

--- a/src/ADNLPProblems/indef_mod.jl
+++ b/src/ADNLPProblems/indef_mod.jl
@@ -1,7 +1,8 @@
 export indef_mod
 
 function indef_mod(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 3 || error("indef : n ≥ 3")
+  n < 3 && @warn("indef_mod: number of variables must be ≥ 4")
+  n = max(3, n)
   function f(x)
     n = length(x)
     return 100 * sum(sin(x[i] / 100) for i = 1:n) +

--- a/src/ADNLPProblems/liarwhd.jl
+++ b/src/ADNLPProblems/liarwhd.jl
@@ -1,7 +1,8 @@
 export liarwhd
 
 function liarwhd(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("liarwhd : n ≥ 2")
+  n < 2 && @warn("liarwhd: number of variables must be ≥ 4")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum(4 * (x[i]^2 - x[1])^2 + (x[i] - 1)^2 for i = 1:n)

--- a/src/ADNLPProblems/ncb20.jl
+++ b/src/ADNLPProblems/ncb20.jl
@@ -2,7 +2,7 @@ export ncb20
 
 function ncb20(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
   n < 31 && @warn("ncb20: number of variables must be ≥ 31")
-  nbis = max(n, 31)
+  n = max(31, n)
   function f(x)
     n = length(x)
     h = T(1 / (n - 1))
@@ -15,8 +15,8 @@ function ncb20(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
            T(1.0e-4) * sum(x[i] * x[i + 10] * x[i + n - 10] + 2 * x[i + n - 10]^2 for i = 1:10)
   end
 
-  x0 = ones(T, nbis)
-  x0[1:(nbis - 10)] .= zero(T)
+  x0 = ones(T, n)
+  x0[1:(n - 10)] .= zero(T)
 
   return ADNLPModels.ADNLPModel(f, x0, name = "ncb20"; kwargs...)
 end

--- a/src/ADNLPProblems/ncb20.jl
+++ b/src/ADNLPProblems/ncb20.jl
@@ -1,7 +1,8 @@
 export ncb20
 
 function ncb20(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 31 || error("ncb20 : n ≥ 31")
+  n < 31 && @warn("ncb20: number of variables must be ≥ 31")
+  nbis = max(n, 31)
   function f(x)
     n = length(x)
     h = T(1 / (n - 1))
@@ -14,8 +15,8 @@ function ncb20(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) 
            T(1.0e-4) * sum(x[i] * x[i + 10] * x[i + n - 10] + 2 * x[i + n - 10]^2 for i = 1:10)
   end
 
-  x0 = ones(T, n)
-  x0[1:(n - 10)] .= zero(T)
+  x0 = ones(T, nbis)
+  x0[1:(nbis - 10)] .= zero(T)
 
   return ADNLPModels.ADNLPModel(f, x0, name = "ncb20"; kwargs...)
 end

--- a/src/ADNLPProblems/ncb20b.jl
+++ b/src/ADNLPProblems/ncb20b.jl
@@ -2,7 +2,7 @@ export ncb20b
 
 function ncb20b(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
   n < 20 && @warn("ncb20b: number of variables must be ≥ 20")
-  nbis = max(n, 20)
+  n = max(20, n)
   function f(x)
     n = length(x)
     h = T(1 / (n - 1))
@@ -11,6 +11,6 @@ function ncb20b(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
       T(0.2) * sum(x[i + j - 1] for j = 1:20) for i = 1:(n - 19)
     ) + sum(100 * x[i]^4 + 2 for i = 1:n)
   end
-  x0 = zeros(T, nbis)
+  x0 = zeros(T, n)
   return ADNLPModels.ADNLPModel(f, x0, name = "ncb20b"; kwargs...)
 end

--- a/src/ADNLPProblems/ncb20b.jl
+++ b/src/ADNLPProblems/ncb20b.jl
@@ -1,7 +1,8 @@
 export ncb20b
 
 function ncb20b(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 20 || error("ncb20 : n ≥ 20")
+  n < 20 && @warn("ncb20b: number of variables must be ≥ 20")
+  nbis = max(n, 20)
   function f(x)
     n = length(x)
     h = T(1 / (n - 1))
@@ -10,6 +11,6 @@ function ncb20b(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...)
       T(0.2) * sum(x[i + j - 1] for j = 1:20) for i = 1:(n - 19)
     ) + sum(100 * x[i]^4 + 2 for i = 1:n)
   end
-  x0 = zeros(T, n)
+  x0 = zeros(T, nbis)
   return ADNLPModels.ADNLPModel(f, x0, name = "ncb20b"; kwargs...)
 end

--- a/src/ADNLPProblems/noncvxu2.jl
+++ b/src/ADNLPProblems/noncvxu2.jl
@@ -1,7 +1,8 @@
 export noncvxu2
 
 function noncvxu2(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("noncvxu2 : n ≥ 2")
+  n < 2 && @warn("noncvxun2: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum(

--- a/src/ADNLPProblems/noncvxun.jl
+++ b/src/ADNLPProblems/noncvxun.jl
@@ -1,7 +1,8 @@
 export noncvxun
 
 function noncvxun(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("noncvxun : n ≥ 2")
+  n < 2 && @warn("noncvxun: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return sum(

--- a/src/ADNLPProblems/nondquar.jl
+++ b/src/ADNLPProblems/nondquar.jl
@@ -1,6 +1,8 @@
 export nondquar
 
 function nondquar(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 2 && @warn("nondquar: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return (x[1] - x[2])^2 + (x[n - 1] - x[n])^2 + sum((x[i] + x[i + 1] + x[n])^4 for i = 1:(n - 2))

--- a/src/ADNLPProblems/penalty2.jl
+++ b/src/ADNLPProblems/penalty2.jl
@@ -1,7 +1,8 @@
 export penalty2
 
 function penalty2(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 3 || error("penalty2 : n ≥ 3")
+  n < 3 && @warn("penalty2: number of variables must be ≥ 3")
+  n = max(3, n)
   function f(x)
     n = length(x)
     a = T(1.0e-5)

--- a/src/ADNLPProblems/penalty3.jl
+++ b/src/ADNLPProblems/penalty3.jl
@@ -1,7 +1,8 @@
 export penalty3
 
 function penalty3(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 3 || error("penalty3 : n ≥ 3")
+  n < 3 && @warn("penalty3: number of variables must be ≥ 3")
+  n = max(3, n)
   function f(x)
     n = length(x)
     return 1 +

--- a/src/ADNLPProblems/sbrybnd.jl
+++ b/src/ADNLPProblems/sbrybnd.jl
@@ -1,7 +1,8 @@
 export sbrybnd
 
 function sbrybnd(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("sbrybnd : n ≥ 2")
+  n < 2 && @warn("sbrybnd: number of variables must be ≥ 2")
+  n = max(2, n)
   p = zeros(T, n)
   J = Array{Any}(undef, n)
   for i = 1:n

--- a/src/ADNLPProblems/schmvett.jl
+++ b/src/ADNLPProblems/schmvett.jl
@@ -1,6 +1,8 @@
 export schmvett
 
 function schmvett(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  n < 3 && @warn("schmvett: number of variables must be ≥ 3")
+  n = max(3, n)
   function f(x)
     n = length(x)
     return sum(

--- a/src/ADNLPProblems/scosine.jl
+++ b/src/ADNLPProblems/scosine.jl
@@ -1,7 +1,8 @@
 export scosine
 
 function scosine(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("scosine : n ≥ 2")
+  n < 2 && @warn("scosine: number of variables must be ≥ 2")
+  n = max(2, n)
   p = zeros(T, n)
   for i = 1:n
     p[i] = exp(6 * (i - 1) / (n - 1))

--- a/src/ADNLPProblems/sparsine.jl
+++ b/src/ADNLPProblems/sparsine.jl
@@ -1,7 +1,8 @@
 export sparsine
 
 function sparsine(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 10 || error("sparsine : n ≥ 10")
+  n < 10 && @warn("sparsine: number of variables must be ≥ 10")
+  n = max(10, n)
   function f(x)
     n = length(x)
     return T(0.5) * sum(

--- a/src/ADNLPProblems/sparsqur.jl
+++ b/src/ADNLPProblems/sparsqur.jl
@@ -1,7 +1,8 @@
 export sparsqur
 
 function sparsqur(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 10 || error("sparsqur : n ≥ 10")
+  n < 10 && @warn("sparsqur: number of variables must be ≥ 10")
+  n = max(10, n)
   function f(x)
     n = length(x)
     return T(1 / 8) * sum(

--- a/src/ADNLPProblems/srosenbr.jl
+++ b/src/ADNLPProblems/srosenbr.jl
@@ -1,7 +1,8 @@
 export srosenbr
 
 function srosenbr(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n = 2 * max(1, div(n, 2))  # number of variables adjusted to be even
+  (n % 2 == 0) || @warn("srosenbr: number of variables adjusted to be even")
+  n = 2 * max(1, div(n, 2))
   function f(x)
     n = length(x)
     return sum(100 * (x[2 * i] - x[2 * i - 1]^2)^2 + (x[2 * i - 1] - 1)^2 for i = 1:div(n, 2))

--- a/src/ADNLPProblems/tointgss.jl
+++ b/src/ADNLPProblems/tointgss.jl
@@ -1,7 +1,8 @@
 export tointgss
 
 function tointgss(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 3 || error("tointgss : n ≥ 3")
+  n < 3 && @warn("tointgss: number of variables must be ≥ 3")
+  n = max(3, n)
   function f(x)
     n = length(x)
     return sum(

--- a/src/ADNLPProblems/tquartic.jl
+++ b/src/ADNLPProblems/tquartic.jl
@@ -1,7 +1,8 @@
 export tquartic
 
 function tquartic(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  n ≥ 2 || error("tquartic : n ≥ 2")
+  n < 2 && @warn("tquartic: number of variables must be ≥ 2")
+  n = max(2, n)
   function f(x)
     n = length(x)
     return (x[1] - 1)^2 + sum((x[1]^2 - x[i + 1]^2)^2 for i = 1:(n - 2))

--- a/src/ADNLPProblems/woods.jl
+++ b/src/ADNLPProblems/woods.jl
@@ -1,6 +1,7 @@
 export woods
 
 function woods(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  (n % 4 == 0) || @warn("woods: number of variables adjusted to be a multiple of 4")
   n = 4 * max(1, div(n, 4))  # number of variables adjusted to be a multiple of 4
   function f(x)
     n = length(x)

--- a/src/ADNLPProblems/woods.jl
+++ b/src/ADNLPProblems/woods.jl
@@ -2,7 +2,7 @@ export woods
 
 function woods(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
   (n % 4 == 0) || @warn("woods: number of variables adjusted to be a multiple of 4")
-  n = 4 * max(1, div(n, 4))  # number of variables adjusted to be a multiple of 4
+  n = 4 * max(1, div(n, 4))
   function f(x)
     n = length(x)
     return 1 + sum(


### PR DESCRIPTION
To be consistent with the PureJuMP models and avoid returning an error.