### PR TITLE
Update docs

### DIFF
--- a/docs/src/benchmark.md
+++ b/docs/src/benchmark.md
@@ -68,7 +68,7 @@ gr()
 profile_solvers(stats, costs, costnames)
 ```
 
-It is also possible to select problems when initializing the problem list by filtering `OptimizationProblems.meta`.
+It is also possible to select problems when initializing the problem list by filtering `OptimizationProblems.meta`:
 ```
 meta = OptimizationProblems.meta
 problem_list = meta[(meta.ncon .== 0) .& .!meta.has_bounds .& (5 .<= meta.nvar .<= 100), :name]

--- a/docs/src/benchmark.md
+++ b/docs/src/benchmark.md
@@ -68,7 +68,7 @@ gr()
 profile_solvers(stats, costs, costnames)
 ```
 
-Note that it is also possible to select the problems when initializing the problem list by searching into the `OptimizationProblems.meta`.
+It is also possible to select problems when initializing the problem list by filtering `OptimizationProblems.meta`.
 ```
 meta = OptimizationProblems.meta
 problem_list = meta[(meta.ncon .== 0) .& .!meta.has_bounds .& (5 .<= meta.nvar .<= 100), :name]

--- a/docs/src/benchmark.md
+++ b/docs/src/benchmark.md
@@ -11,12 +11,12 @@ using JSOSolvers, NLPModels, NLPModelsJuMP, OptimizationProblems, OptimizationPr
 ```
 We select the problems from `PureJuMP` submodule of `OptimizationProblems` converted in [NLPModels](https://github.com/JuliaSmoothOptimizers/NLPModels.jl) using [NLPModelsJuMP](https://github.com/JuliaSmoothOptimizers/NLPModelsJuMP.jl).
 ``` @example ex1
-problems = (MathOptNLPModel(eval(problem)(), name=string(problem)) for problem ∈ filter(x -> x != :PureJuMP, names(OptimizationProblems.PureJuMP)))
+problems = (MathOptNLPModel(eval(Meta.parse(problem))(), name=problem) for problem ∈ OptimizationProblems.meta[!, :name])
 ```
 The same can be achieved using `OptimizationProblems.ADNLPProblems` as follows:
 ``` @example ex1
 using ADNLPModels
-ad_problems = (eval(problem)() for problem ∈ setdiff(names(OptimizationProblems.ADNLPProblems), [:ADNLPProblems]))
+ad_problems = (eval(Meta.parse(problem))() for problem ∈ OptimizationProblems.meta[!, :name])
 ```
 
 We also define a dictionary of solvers that will be used for our benchmark. We consider here `JSOSolvers.lbfgs` and `JSOSolvers.trunk`.
@@ -66,4 +66,11 @@ using Plots
 gr()
 
 profile_solvers(stats, costs, costnames)
+```
+
+Note that it is also possible to select the problems when initializing the problem list by searching into the `OptimizationProblems.meta`.
+```
+meta = OptimizationProblems.meta
+problem_list = meta[(meta.ncon .== 0) .& .!meta.has_bounds .& (5 .<= meta.nvar .<= 100), :name]
+problems = (MathOptNLPModel(eval(Meta.parse(problem))(), name=problem) for problem ∈ problem_list)
 ```

--- a/docs/src/meta.md
+++ b/docs/src/meta.md
@@ -3,7 +3,7 @@
 It is possible to access information on the problems implemented in `OptimizationProblems.jl` without loading the problems using the package's own classification.
 ​
 ```@example 1
-using ADNLPModels, OptimizationProblems
+using OptimizationProblems
 ```
 
 Each problem has its own metadata structure, and there is a global metadata structure regrouping all the information.
@@ -45,6 +45,7 @@ names_pb_vars = meta[(meta.variable_nvar .== true) .& (meta.ncon .== 0), [:nvar,
 ```
 Then, one can prepare a list of problems using the selected ones.
 ```@example 1
+using ADNLPModels
 adproblems = (
   eval(Meta.parse("ADNLPProblems.$(pb[:name])()")) for pb in eachrow(names_pb_vars)
 )

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -5,17 +5,22 @@ This package is subdivided in two submodules: `PureJuMP` for the JuMP problems, 
 
 ## Problems in JuMP syntax: PureJuMP
 
-You can obtain the list of problems currently defined with `names(OptimizationProblems.PureJuMP)` that returns the list of exported names of the submodule. The symbol `:PureJuMP` is itself in this list.
+You can obtain the list of problems currently defined with `OptimizationProblems.meta[!, :name]` that returns the list of exported names of the submodule.
 ``` @example ex1
 using OptimizationProblems, OptimizationProblems.PureJuMP
-problems = setdiff(names(OptimizationProblems.PureJuMP), [:PureJuMP])
+problems = OptimizationProblems.meta[!, :name]
 length(problems)
 ```
 Then, it suffices to select any of this problem to get the JuMP model.
 ``` @example ex1
 jump_model = zangwil3()
 ```
-Note that some of these problems are scalable, i.e., their size depends on some parameters that can be modified.
+Note that some of these problems are scalable, i.e., their size depends on some parameters that can be modified. The list is available once again using the `meta`.
+``` @example ex1
+var_problems = OptimizationProblems.meta[OptimizationProblems.meta.variable_nvar, :name]
+length(var_problems)
+```
+Then, using the keyword `n`, it is possible to specify the targeted number of variables.
 ``` @example ex1
 jump_model_12 = woods(n=12)
 ```
@@ -31,10 +36,10 @@ This package also offers [ADNLPModel](https://github.com/JuliaSmoothOptimizers/A
 ``` @example ex2
 using ADNLPModels
 ```
-You can obtain the list of problems currently defined with `names(OptimizationProblems.ADNLPProblems)` that returns the list of exported names of the submodule. The symbol `:ADNLPProblems` is itself in this list.
+You can obtain the list of problems currently defined with `OptimizationProblems.meta[!, :name]` that returns the list of exported names of the submodule.
 ``` @example ex2
 using OptimizationProblems, OptimizationProblems.ADNLPProblems
-problems = setdiff(names(OptimizationProblems.ADNLPProblems), [:ADNLPProblems])
+problems = OptimizationProblems.meta[!, :name]
 length(problems)
 ```
 Similarly, to the PureJuMP models, it suffices to select any of this problem to get the model.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -15,7 +15,7 @@ Then, it suffices to select any of this problem to get the JuMP model.
 ``` @example ex1
 jump_model = zangwil3()
 ```
-Note that certain problems are scalable, i.e., their size depends on parameters that can be modified. The list of those problems is available once again using `meta`.
+Note that certain problems are scalable, i.e., their size depends on parameters that can be modified. The list of those problems is available once again using `meta`:
 ``` @example ex1
 var_problems = OptimizationProblems.meta[OptimizationProblems.meta.variable_nvar, :name]
 length(var_problems)

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -36,7 +36,7 @@ This package also offers [ADNLPModel](https://github.com/JuliaSmoothOptimizers/A
 ``` @example ex2
 using ADNLPModels
 ```
-You can obtain the list of problems currently defined with `OptimizationProblems.meta[!, :name]` that returns the list of exported names of the submodule.
+You can obtain the list of problems currently defined with `OptimizationProblems.meta[!, :name]`.
 ``` @example ex2
 using OptimizationProblems, OptimizationProblems.ADNLPProblems
 problems = OptimizationProblems.meta[!, :name]

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -5,7 +5,7 @@ This package is subdivided in two submodules: `PureJuMP` for the JuMP problems, 
 
 ## Problems in JuMP syntax: PureJuMP
 
-You can obtain the list of problems currently defined with `OptimizationProblems.meta[!, :name]` that returns the list of exported names of the submodule.
+You can obtain the list of problems currently defined with `OptimizationProblems.meta[!, :name]`.
 ``` @example ex1
 using OptimizationProblems, OptimizationProblems.PureJuMP
 problems = OptimizationProblems.meta[!, :name]

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -36,7 +36,7 @@ This package also offers [ADNLPModel](https://github.com/JuliaSmoothOptimizers/A
 ``` @example ex2
 using ADNLPModels
 ```
-You can obtain the list of problems currently defined with `OptimizationProblems.meta[!, :name]`.
+You can obtain the list of problems currently defined with `OptimizationProblems.meta[!, :name]`:
 ``` @example ex2
 using OptimizationProblems, OptimizationProblems.ADNLPProblems
 problems = OptimizationProblems.meta[!, :name]

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -15,7 +15,7 @@ Then, it suffices to select any of this problem to get the JuMP model.
 ``` @example ex1
 jump_model = zangwil3()
 ```
-Note that some of these problems are scalable, i.e., their size depends on some parameters that can be modified. The list is available once again using the `meta`.
+Note that certain problems are scalable, i.e., their size depends on parameters that can be modified. The list of those problems is available once again using `meta`.
 ``` @example ex1
 var_problems = OptimizationProblems.meta[OptimizationProblems.meta.variable_nvar, :name]
 length(var_problems)

--- a/src/ADNLPProblems/hovercraft1d.jl
+++ b/src/ADNLPProblems/hovercraft1d.jl
@@ -16,7 +16,7 @@ function hovercraft1d(
     return vcat(
       x[1],
       v[1],
-      x[N] - 100,
+      x[N],
       v[N],
       [x[i + 1] - x[i] - v[i] for i = 1:(N - 1)],
       [v[i + 1] - v[i] - u[i] for i = 1:(N - 1)],
@@ -27,8 +27,8 @@ function hovercraft1d(
     f,
     xi,
     c,
-    zeros(T, 2 * N + 2),
-    zeros(T, 2 * N + 2),
+    vcat(zeros(T, 2), T(100), zeros(T, 2 * N - 1)),
+    vcat(zeros(T, 2), T(100), zeros(T, 2 * N - 1)),
     name = "hovercraft1d";
     lin = collect(1:(2 * N + 2)),
     kwargs...,

--- a/src/Meta/clplatea.jl
+++ b/src/Meta/clplatea.jl
@@ -1,6 +1,6 @@
 clplatea_meta = Dict(
-  :nvar => 5041,
-  :variable_nvar => false,
+  :nvar => default_nvar,
+  :variable_nvar => true,
   :ncon => 0,
   :variable_ncon => false,
   :minimize => true,
@@ -17,7 +17,7 @@ clplatea_meta = Dict(
   :defined_everywhere => missing,
   :origin => :unknown,
 )
-get_clplatea_nvar(; n::Integer = default_nvar, kwargs...) = 5041
+get_clplatea_nvar(; n::Integer = default_nvar, kwargs...) = n
 get_clplatea_ncon(; n::Integer = default_nvar, kwargs...) = 0
 get_clplatea_nlin(; n::Integer = default_nvar, kwargs...) = 0
 get_clplatea_nnln(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/clplatea.jl
+++ b/src/Meta/clplatea.jl
@@ -17,7 +17,7 @@ clplatea_meta = Dict(
   :defined_everywhere => missing,
   :origin => :unknown,
 )
-get_clplatea_nvar(; n::Integer = default_nvar, kwargs...) = n
+get_clplatea_nvar(; n::Integer = default_nvar, kwargs...) = floor(Int, sqrt(n))^2
 get_clplatea_ncon(; n::Integer = default_nvar, kwargs...) = 0
 get_clplatea_nlin(; n::Integer = default_nvar, kwargs...) = 0
 get_clplatea_nnln(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/clplateb.jl
+++ b/src/Meta/clplateb.jl
@@ -1,5 +1,5 @@
 clplateb_meta = Dict(
-  :nvar => 5041,
+  :nvar => default_nvar,
   :variable_nvar => false,
   :ncon => 0,
   :variable_ncon => false,
@@ -17,7 +17,7 @@ clplateb_meta = Dict(
   :defined_everywhere => missing,
   :origin => :unknown,
 )
-get_clplateb_nvar(; n::Integer = default_nvar, kwargs...) = 5041
+get_clplateb_nvar(; n::Integer = default_nvar, kwargs...) = n
 get_clplateb_ncon(; n::Integer = default_nvar, kwargs...) = 0
 get_clplateb_nlin(; n::Integer = default_nvar, kwargs...) = 0
 get_clplateb_nnln(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/clplateb.jl
+++ b/src/Meta/clplateb.jl
@@ -1,6 +1,6 @@
 clplateb_meta = Dict(
   :nvar => default_nvar,
-  :variable_nvar => false,
+  :variable_nvar => true,
   :ncon => 0,
   :variable_ncon => false,
   :minimize => true,

--- a/src/Meta/clplateb.jl
+++ b/src/Meta/clplateb.jl
@@ -17,7 +17,7 @@ clplateb_meta = Dict(
   :defined_everywhere => missing,
   :origin => :unknown,
 )
-get_clplateb_nvar(; n::Integer = default_nvar, kwargs...) = n
+get_clplateb_nvar(; n::Integer = default_nvar, kwargs...) = floor(Int, sqrt(n))^2
 get_clplateb_ncon(; n::Integer = default_nvar, kwargs...) = 0
 get_clplateb_nlin(; n::Integer = default_nvar, kwargs...) = 0
 get_clplateb_nnln(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/clplatec.jl
+++ b/src/Meta/clplatec.jl
@@ -1,6 +1,6 @@
 clplatec_meta = Dict(
   :nvar => default_nvar,
-  :variable_nvar => false,
+  :variable_nvar => true,
   :ncon => 0,
   :variable_ncon => false,
   :minimize => true,

--- a/src/Meta/clplatec.jl
+++ b/src/Meta/clplatec.jl
@@ -1,5 +1,5 @@
 clplatec_meta = Dict(
-  :nvar => 5041,
+  :nvar => default_nvar,
   :variable_nvar => false,
   :ncon => 0,
   :variable_ncon => false,
@@ -17,7 +17,7 @@ clplatec_meta = Dict(
   :defined_everywhere => missing,
   :origin => :unknown,
 )
-get_clplatec_nvar(; n::Integer = default_nvar, kwargs...) = 5041
+get_clplatec_nvar(; n::Integer = default_nvar, kwargs...) = n
 get_clplatec_ncon(; n::Integer = default_nvar, kwargs...) = 0
 get_clplatec_nlin(; n::Integer = default_nvar, kwargs...) = 0
 get_clplatec_nnln(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/Meta/clplatec.jl
+++ b/src/Meta/clplatec.jl
@@ -17,7 +17,7 @@ clplatec_meta = Dict(
   :defined_everywhere => missing,
   :origin => :unknown,
 )
-get_clplatec_nvar(; n::Integer = default_nvar, kwargs...) = n
+get_clplatec_nvar(; n::Integer = default_nvar, kwargs...) = floor(Int, sqrt(n))^2
 get_clplatec_ncon(; n::Integer = default_nvar, kwargs...) = 0
 get_clplatec_nlin(; n::Integer = default_nvar, kwargs...) = 0
 get_clplatec_nnln(; n::Integer = default_nvar, kwargs...) = 0

--- a/src/PureJuMP/hovercraft1d.jl
+++ b/src/PureJuMP/hovercraft1d.jl
@@ -3,6 +3,7 @@
 
 # Hovercraft 1D example
 # https://laurentlessard.com/teaching/524-intro-to-optimization/
+export hovercraft1d
 
 function hovercraft1d(args...; n::Int = default_nvar, kwargs...)
   nlp = Model()


### PR DESCRIPTION
We can now use the `meta` to get the names of the problems for PureJuMP and ADNLPProblems.

I fixed some more typos when updating the benchmark.