### PR TITLE
Pi convertion in AMPGO14 and schmvett

### DIFF
--- a/src/ADNLPProblems/AMPGO14.jl
+++ b/src/ADNLPProblems/AMPGO14.jl
@@ -3,7 +3,7 @@ export AMPGO14
 function AMPGO14(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
   function f(x)
     n = length(x)
-    return -exp(-x[1]) * sin(2 * (pi * x[1]))
+    return -exp(-x[1]) * sin(2 * (T(pi) * x[1]))
   end
   x0 = zeros(T, 1)
   return ADNLPModels.ADNLPModel(f, x0, name = "AMPGO14"; kwargs...)

--- a/src/ADNLPProblems/schmvett.jl
+++ b/src/ADNLPProblems/schmvett.jl
@@ -6,7 +6,7 @@ function schmvett(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   function f(x)
     n = length(x)
     return sum(
-      -(1 / (1 + (x[i] - x[i + 1])^2)) - sin((π * x[i + 1] + x[i + 2]) / 2) -
+      -(1 / (1 + (x[i] - x[i + 1])^2)) - sin((T(π) * x[i + 1] + x[i + 2]) / 2) -
       exp(-((x[i] + x[i + 2]) / x[i + 1] - 2)^2) for i = 1:(n - 2)
     )
   end


### PR DESCRIPTION
Convert pi into T(pi), ensures type stability of the models.