### PR TITLE
Add a size limit on the jacobian test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,9 @@ for prob in names(PureJuMP)
     @test all(isapprox.(cons(nlp_ad, x1), cons(nlp_jump, x1), atol = 1e-10 * n0))
     @test all(isapprox.(cons(nlp_ad, x2), cons(nlp_jump, x2), atol = 1e-10 * n0))
     @test nlp_jump.meta.lin == nlp_ad.meta.lin
-    jac(nlp_ad, x1) # just test that it runs
+    if nlp_ad.meta.nvar <= 10000 & nlp_ad.meta.ncon <= 10000
+      jac(nlp_ad, x1) # just test that it runs
+    end
   end
 
   meta_sanity_check(prob, nlp_ad)


### PR DESCRIPTION
https://github.com/JuliaSmoothOptimizers/OptimizationProblems.jl/pull/191/checks?check_run_id=6791294225

is failing for `tetra_duct12` which has 12 000 variables and 19 000 constraints.