### PR TITLE
add `ADNLSModel` constructor in `arglina`

### DIFF
--- a/src/ADNLPProblems/arglina.jl
+++ b/src/ADNLPProblems/arglina.jl
@@ -1,6 +1,11 @@
 export arglina
 
-function arglina(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+function arglina(;use_nls = false, kwargs...)
+  model = use_nls ? :nls : nlp
+  return arglina(Val(model); kwargs...)
+end
+
+function arglina(::Val{:nlp}; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
   function f(x; n = length(x))
     m = 2 * n
     sj = sum(x[j] for j = 1:n)
@@ -8,4 +13,18 @@ function arglina(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...
   end
   x0 = ones(T, n)
   return ADNLPModels.ADNLPModel(f, x0, name = "arglina"; kwargs...)
+end
+
+function arglina(::Val{:nls}; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
+  function F!(r, x)
+    m = 2 * n
+    sj = sum(x[j] for j = 1:n)
+    for i=1:n
+      r[i] = x[i] - 2 // m * sj - 1
+      r[i + n] = - 2 // m * sj - 1
+    end
+    return r
+  end
+  x0 = ones(T, n)
+  return ADNLPModels.ADNLSModel!(F!, x0, 2 * n, name = "arglina-nls"; kwargs...)
 end

--- a/src/ADNLPProblems/arglina.jl
+++ b/src/ADNLPProblems/arglina.jl
@@ -1,7 +1,7 @@
 export arglina
 
-function arglina(;use_nls = false, kwargs...)
-  model = use_nls ? :nls : nlp
+function arglina(;use_nls::Bool = false, kwargs...)
+  model = use_nls ? :nls : :nlp
   return arglina(Val(model); kwargs...)
 end
 
@@ -9,7 +9,7 @@ function arglina(::Val{:nlp}; n::Int = default_nvar, type::Val{T} = Val(Float64)
   function f(x; n = length(x))
     m = 2 * n
     sj = sum(x[j] for j = 1:n)
-    return sum((x[i] - 2 // m * sj - 1)^2 for i = 1:n) + sum((-2 // m * sj - 1)^2 for i = (n + 1):m)
+    return 1 // 2 * sum((x[i] - 2 // m * sj - 1)^2 for i = 1:n) + 1 // 2 * sum((-2 // m * sj - 1)^2 for i = (n + 1):m)
   end
   x0 = ones(T, n)
   return ADNLPModels.ADNLPModel(f, x0, name = "arglina"; kwargs...)

--- a/src/Meta/arglina.jl
+++ b/src/Meta/arglina.jl
@@ -23,3 +23,4 @@ get_arglina_nlin(; n::Integer = default_nvar, kwargs...) = 0
 get_arglina_nnln(; n::Integer = default_nvar, kwargs...) = 0
 get_arglina_nequ(; n::Integer = default_nvar, kwargs...) = 0
 get_arglina_nineq(; n::Integer = default_nvar, kwargs...) = 0
+get_arglina_nls_nequ(; n::Integer = default_nvar, kwargs...) = 2 * n

--- a/src/PureJuMP/arglina.jl
+++ b/src/PureJuMP/arglina.jl
@@ -23,8 +23,8 @@ function arglina(args...; n::Int = default_nvar, m::Int = 2n, kwargs...)
   @NLobjective(
     nlp,
     Min,
-    sum((x[i] - 2 / m * sum(x[j] for j = 1:n) - 1)^2 for i = 1:n) +
-    sum((-2 / m * sum(x[j] for j = 1:n) - 1)^2 for i = (n + 1):m)
+    0.5 * sum((x[i] - 2 / m * sum(x[j] for j = 1:n) - 1)^2 for i = 1:n) +
+    0.5 * sum((-2 / m * sum(x[j] for j = 1:n) - 1)^2 for i = (n + 1):m)
   )
 
   return nlp


### PR DESCRIPTION
This is an example of how we could use ADNLSModel for the least square objective.

Currently, the tests break because in the JuMP models currently implemented we generally don't have the `1/2` factor in front of the objective. #162 

@abelsiqueira @dpo Any opinion on this?