### PR TITLE
Remove `jac` call in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,9 +66,6 @@ for prob in names(PureJuMP)
     @test all(isapprox.(cons(nlp_ad, x1), cons(nlp_jump, x1), atol = 1e-10 * n0))
     @test all(isapprox.(cons(nlp_ad, x2), cons(nlp_jump, x2), atol = 1e-10 * n0))
     @test nlp_jump.meta.lin == nlp_ad.meta.lin
-    if nlp_ad.meta.nvar <= 10000 & nlp_ad.meta.ncon <= 10000
-      jac(nlp_ad, x1) # just test that it runs
-    end
   end
 
   meta_sanity_check(prob, nlp_ad)


### PR DESCRIPTION
I want to check if that fixes the test for windows
https://github.com/JuliaSmoothOptimizers/OptimizationProblems.jl/runs/7883615463?check_suite_focus=true
https://github.com/JuliaSmoothOptimizers/OptimizationProblems.jl/runs/7883615125?check_suite_focus=true