### PR TITLE
Convert data in `palmer`

### DIFF
--- a/src/ADNLPProblems/palmer1c.jl
+++ b/src/ADNLPProblems/palmer1c.jl
@@ -1,7 +1,7 @@
 export palmer1c
 
 function palmer1c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     -1.788963,
     -1.745329,
     -1.658063,
@@ -39,7 +39,7 @@ function palmer1c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     1.8325957,
   ]
 
-  Y = T[
+  Y = [
     78.596218,
     65.77963,
     43.96947,
@@ -78,7 +78,8 @@ function palmer1c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8))^2 for i = 1:35)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:8))^2 for i = 1:35)
   end
   x0 = ones(T, 8)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer1c"; kwargs...)

--- a/src/ADNLPProblems/palmer1d.jl
+++ b/src/ADNLPProblems/palmer1d.jl
@@ -1,7 +1,7 @@
 export palmer1d
 
 function palmer1d(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     -1.788963,
     -1.745329,
     -1.658063,
@@ -39,7 +39,7 @@ function palmer1d(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     1.8325957,
   ]
 
-  Y = T[
+  Y = [
     78.596218,
     65.77963,
     43.96947,
@@ -78,7 +78,8 @@ function palmer1d(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:7))^2 for i = 1:35)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:7))^2 for i = 1:35)
   end
   x0 = ones(T, 7)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer1d"; kwargs...)

--- a/src/ADNLPProblems/palmer2c.jl
+++ b/src/ADNLPProblems/palmer2c.jl
@@ -1,7 +1,7 @@
 export palmer2c
 
 function palmer2c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     -1.745329,
     -1.570796,
     -1.396263,
@@ -27,7 +27,7 @@ function palmer2c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     1.745329,
   ]
 
-  Y = T[
+  Y = [
     72.676767,
     40.149455,
     18.8548,
@@ -54,7 +54,8 @@ function palmer2c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8))^2 for i = 1:23)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:8))^2 for i = 1:23)
   end
   x0 = ones(T, 8)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer2c"; kwargs...)

--- a/src/ADNLPProblems/palmer3c.jl
+++ b/src/ADNLPProblems/palmer3c.jl
@@ -1,7 +1,7 @@
 export palmer3c
 
 function palmer3c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     -1.658063,
     -1.570796,
     -1.396263,
@@ -27,7 +27,7 @@ function palmer3c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     1.658063,
   ]
 
-  Y = T[
+  Y = [
     64.87939,
     50.46046,
     28.2034,
@@ -54,7 +54,8 @@ function palmer3c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8))^2 for i = 1:23)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:8))^2 for i = 1:23)
   end
   x0 = ones(T, 8)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer3c"; kwargs...)

--- a/src/ADNLPProblems/palmer4c.jl
+++ b/src/ADNLPProblems/palmer4c.jl
@@ -1,7 +1,7 @@
 export palmer4c
 
 function palmer4c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     -1.658063,
     -1.570796,
     -1.396263,
@@ -27,7 +27,7 @@ function palmer4c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     1.658063,
   ]
 
-  Y = T[
+  Y = [
     67.27625,
     52.8537,
     30.2718,
@@ -54,7 +54,8 @@ function palmer4c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8))^2 for i = 1:23)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:8))^2 for i = 1:23)
   end
   x0 = ones(T, 8)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer4c"; kwargs...)

--- a/src/ADNLPProblems/palmer5c.jl
+++ b/src/ADNLPProblems/palmer5c.jl
@@ -1,7 +1,7 @@
 export palmer5c
 
 function palmer5c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     0.000000,
     1.570796,
     1.396263,
@@ -16,7 +16,7 @@ function palmer5c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     0.174533,
   ]
 
-  Y = T[
+  Y = [
     83.57418,
     81.007654,
     18.983286,
@@ -45,7 +45,8 @@ function palmer5c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   end
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * t[i, 2 * j - 1] for j = 1:6))^2 for i = 1:12)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(t[i, 2 * j - 1]) for j = 1:6))^2 for i = 1:12)
   end
   x0 = ones(T, 6)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer5c"; kwargs...)

--- a/src/ADNLPProblems/palmer5d.jl
+++ b/src/ADNLPProblems/palmer5d.jl
@@ -1,7 +1,7 @@
 export palmer5d
 
 function palmer5d(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     0.000000,
     1.570796,
     1.396263,
@@ -16,7 +16,7 @@ function palmer5d(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     0.174533,
   ]
 
-  Y = T[
+  Y = [
     83.57418,
     81.007654,
     18.983286,
@@ -32,7 +32,8 @@ function palmer5d(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:4))^2 for i = 1:12)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:4))^2 for i = 1:12)
   end
   x0 = ones(T, 4)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer5d"; kwargs...)

--- a/src/ADNLPProblems/palmer6c.jl
+++ b/src/ADNLPProblems/palmer6c.jl
@@ -1,7 +1,7 @@
 export palmer6c
 
 function palmer6c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     0.000000,
     1.570796,
     1.396263,
@@ -17,7 +17,7 @@ function palmer6c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     0.174533,
   ]
 
-  Y = T[
+  Y = [
     10.678659,
     75.414511,
     41.513459,
@@ -34,7 +34,8 @@ function palmer6c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8))^2 for i = 1:13)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:8))^2 for i = 1:13)
   end
   x0 = ones(T, 8)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer6c"; kwargs...)

--- a/src/ADNLPProblems/palmer7c.jl
+++ b/src/ADNLPProblems/palmer7c.jl
@@ -1,7 +1,7 @@
 export palmer7c
 
 function palmer7c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     0.000000,
     0.139626,
     0.261799,
@@ -17,7 +17,7 @@ function palmer7c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     1.658063,
   ]
 
-  Y = T[
+  Y = [
     4.419446,
     3.564931,
     2.139067,
@@ -34,7 +34,8 @@ function palmer7c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8))^2 for i = 1:13)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:8))^2 for i = 1:13)
   end
   x0 = ones(T, 8)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer7c"; kwargs...)

--- a/src/ADNLPProblems/palmer8c.jl
+++ b/src/ADNLPProblems/palmer8c.jl
@@ -1,7 +1,7 @@
 export palmer8c
 
 function palmer8c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
-  X = T[
+  X = [
     0.000000,
     0.174533,
     0.314159,
@@ -16,7 +16,7 @@ function palmer8c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
     1.570796,
   ]
 
-  Y = T[
+  Y = [
     4.757534,
     3.121416,
     1.207606,
@@ -32,7 +32,8 @@ function palmer8c(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs..
   ]
   function f(x)
     n = length(x)
-    return sum((Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8))^2 for i = 1:12)
+    Ti = eltype(x)
+    return sum((Ti(Y[i]) - sum(x[j] * Ti(X[i])^(2 * j - 2) for j = 1:8))^2 for i = 1:12)
   end
   x0 = ones(T, 8)
   return ADNLPModels.ADNLPModel(f, x0, name = "palmer8c"; kwargs...)


### PR DESCRIPTION
Complementing #221 
We cannot convert `X` and `Y` as `Rational{Int}` since the function `f` is taking a large power of it and this fails.