### PR TITLE
Make `arwheadnlp.f(x)` allocation-free

### DIFF
--- a/src/ADNLPProblems/arwhead.jl
+++ b/src/ADNLPProblems/arwhead.jl
@@ -3,8 +3,7 @@ export arwhead
 function arwhead(; n::Int = default_nvar, type::Val{T} = Val(Float64), kwargs...) where {T}
   n < 2 && @warn("arwhead: number of variables must be ≥ 2")
   n = max(2, n)
-  function f(x)
-    n = length(x)
+  function f(x; n=length(x))
     return sum((x[i]^2 + x[n]^2)^2 - 4 * x[i] + 3 for i = 1:(n - 1))
   end
   x0 = ones(T, n)


### PR DESCRIPTION
@tmigot, following this [discussion](https://github.com/JuliaSmoothOptimizers/PartiallySeparableNLPModels.jl/discussions/63#discussioncomment-4450738).