### PR TITLE
Be more flexible in arguments of residual for NLS problems

### DIFF
--- a/src/ADNLPProblems/errinros_mod.jl
+++ b/src/ADNLPProblems/errinros_mod.jl
@@ -29,7 +29,7 @@ function errinros_mod(
 ) where {T}
   n < 2 && @warn("errinros_mod: number of variables must be ≥ 2")
   n = max(2, n)
-  function F!(r::AbstractVector{Ti}, x::AbstractVector{Ti}; n = length(x)) where {Ti}
+  function F!(r::AbstractVector{Ti}, x; n = length(x)) where {Ti}
     for i = 2:n
       r[i - 1] = x[i - 1] - 16 * x[i]^2 * (15 // 10 + sin(i * one(Ti)))^2
       r[i - 1 + n - 1] = 1 - x[i]

--- a/src/ADNLPProblems/palmer1c.jl
+++ b/src/ADNLPProblems/palmer1c.jl
@@ -175,7 +175,7 @@ function palmer1c(
     108.18086,
     92.733676,
   ]
-  function F!(r, x; X = eltype(x).(X), Y = eltype(x).(Y))
+  function F!(r::AbstractVector{Ti}, x; X = Ti.(X), Y = Ti.(Y)) where {Ti} 
     for i = 1:35
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8)
     end

--- a/src/ADNLPProblems/palmer1d.jl
+++ b/src/ADNLPProblems/palmer1d.jl
@@ -177,9 +177,9 @@ function palmer1d(
   ]
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    X::AbstractVector{Ti} = Ti.(X),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    X = Ti.(X),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:35
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:7)

--- a/src/ADNLPProblems/palmer2c.jl
+++ b/src/ADNLPProblems/palmer2c.jl
@@ -129,9 +129,9 @@ function palmer2c(
   ]
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    X::AbstractVector{Ti} = Ti.(X),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    X = Ti.(X),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:23
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8)

--- a/src/ADNLPProblems/palmer3c.jl
+++ b/src/ADNLPProblems/palmer3c.jl
@@ -130,9 +130,9 @@ function palmer3c(
 
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    X::AbstractVector{Ti} = Ti.(X),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    X = Ti.(X),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:23
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8)

--- a/src/ADNLPProblems/palmer4c.jl
+++ b/src/ADNLPProblems/palmer4c.jl
@@ -130,9 +130,9 @@ function palmer4c(
 
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    X::AbstractVector{Ti} = Ti.(X),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    X = Ti.(X),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:23
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8)

--- a/src/ADNLPProblems/palmer5c.jl
+++ b/src/ADNLPProblems/palmer5c.jl
@@ -112,9 +112,9 @@ function palmer5c(
 
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    t::AbstractMatrix{Ti} = Ti.(t),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    t = Ti.(t),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:12
       r[i] = Y[i] - sum(x[j] * t[i, 2 * j - 1] for j = 1:6)

--- a/src/ADNLPProblems/palmer5d.jl
+++ b/src/ADNLPProblems/palmer5d.jl
@@ -85,9 +85,9 @@ function palmer5d(
   ]
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    X::AbstractVector{Ti} = Ti.(X),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    X = Ti.(X),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:12
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:4)

--- a/src/ADNLPProblems/palmer6c.jl
+++ b/src/ADNLPProblems/palmer6c.jl
@@ -90,9 +90,9 @@ function palmer6c(
 
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    X::AbstractVector{Ti} = Ti.(X),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    X = Ti.(X),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:13
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8)

--- a/src/ADNLPProblems/palmer7c.jl
+++ b/src/ADNLPProblems/palmer7c.jl
@@ -89,9 +89,9 @@ function palmer7c(
   ]
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    X::AbstractVector{Ti} = Ti.(X),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    X = Ti.(X),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:13
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8)

--- a/src/ADNLPProblems/palmer8c.jl
+++ b/src/ADNLPProblems/palmer8c.jl
@@ -85,9 +85,9 @@ function palmer8c(
   ]
   function F!(
     r::AbstractVector{Ti},
-    x::AbstractVector{Ti};
-    X::AbstractVector{Ti} = Ti.(X),
-    Y::AbstractVector{Ti} = Ti.(Y),
+    x;
+    X = Ti.(X),
+    Y = Ti.(Y),
   ) where {Ti}
     for i = 1:12
       r[i] = Y[i] - sum(x[j] * X[i]^(2 * j - 2) for j = 1:8)


### PR DESCRIPTION
Motivated by the following error when using ReverseDiff `jtprod`:

Test Nonlinear Least Squares for palmer8c: Error During Test at C:\Users\tangi\Documents\cvs\OptimizationProblems.jl\test\runtests.jl:48
  Got exception outside of a @test
  MethodError: no method matching (::OptimizationProblems.ADNLPProblems.var"#F!#1636"{OptimizationProblems.ADNLPProblems.var"#F!#1634#1637", Vector{Float64}, Vector{Float64}})(::Vector{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}, ::ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}})