### PR TITLE
Avoid load in tetra and triangle

### DIFF
--- a/src/ADNLPProblems/tetra.jl
+++ b/src/ADNLPProblems/tetra.jl
@@ -6,7 +6,7 @@
 #   see "Benchmarking Optimization Software with COPS"
 #   Argonne National Labs Technical Report ANL/MCS-246 (2004)
 
-@load joinpath(data_path, "data_tetra.jld2") xe_tetra Tets_tetra Constants_tetra
+include("../../data/tetra.jl")
 export tetra
 
 function tetra(
@@ -71,29 +71,30 @@ function tetra(
   return ADNLPModels.ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, name = "tetra"; kwargs...)
 end
 
-@load joinpath(data_path, "data_tetra_duct12.jld2") xe_duct12 TETS_duct12 Const_duct12
+include("../../data/tetra_duct12.jl")
 export tetra_duct12
 tetra_duct12(; kwargs...) =
   tetra(xe_duct12, TETS_duct12, Const_duct12; name = "tetra_duct12", kwargs...)
 
-@load joinpath(data_path, "data_tetra_duct15.jld2") xe_duct15 TETS_duct15 Const_duct15
+include("../../data/tetra_duct15.jl")
 export tetra_duct15
 tetra_duct15(; kwargs...) =
   tetra(xe_duct15, TETS_duct15, Const_duct15; name = "tetra_duct15", kwargs...)
 
-@load joinpath(data_path, "data_tetra_duct20.jld2") xe_duct20 TETS_duct20 Const_duct20
+  include("../../data/tetra_duct20.jl")
 export tetra_duct20
 tetra_duct20(; kwargs...) =
   tetra(xe_duct20, TETS_duct20, Const_duct20; name = "tetra_duct20", kwargs...)
 
-@load joinpath(data_path, "data_tetra_hook.jld2") xe_hook TETS_hook Const_hook
+include("../../data/tetra_hook.jl")
 export tetra_hook
 tetra_hook(; kwargs...) = tetra(xe_hook, TETS_hook, Const_hook; name = "tetra_hook", kwargs...)
 
-@load joinpath(data_path, "data_tetra_foam5.jld2") xe_foam5 TETS_foam5 Const_foam5
+include("../../data/tetra_foam5.jl")
 export tetra_foam5
 tetra_foam5(; kwargs...) = tetra(xe_foam5, TETS_foam5, Const_foam5; name = "tetra_foam5", kwargs...)
 
-@load joinpath(data_path, "data_tetra_gear.jld2") xe_gear TETS_gear Const_gear
+include("../../data/tetra_gear.jl")
 export tetra_gear
 tetra_gear(; kwargs...) = tetra(xe_gear, TETS_gear, Const_gear; name = "tetra_gear", kwargs...)
+# TRUC

--- a/src/ADNLPProblems/triangle.jl
+++ b/src/ADNLPProblems/triangle.jl
@@ -6,7 +6,7 @@
 #   see "Benchmarking Optimization Software with COPS"
 #   Argonne National Labs Technical Report ANL/MCS-246 (2004)
 
-@load joinpath(data_path, "data_triangle.jld2") xe Tr Constants
+include("../../data/triangle.jl")
 export triangle
 
 function triangle(
@@ -60,17 +60,17 @@ function triangle(
   return ADNLPModels.ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, name = "triangle"; kwargs...)
 end
 
-@load joinpath(data_path, "data_triangle_deer.jld2") xe_deer TRIS_deer Const_deer
+include("../../data/triangle_deer.jl")
 export triangle_deer
 triangle_deer(; kwargs...) =
   triangle(xe_deer, TRIS_deer, Const_deer; name = "triangle_deer", kwargs...)
 
-@load joinpath(data_path, "data_triangle_pacman.jld2") xe_pacman TRIS_pacman Const_pacman
+include("../../data/triangle_pacman.jl")
 export triangle_pacman
 triangle_pacman(; kwargs...) =
   triangle(xe_pacman, TRIS_pacman, Const_pacman; name = "triangle_pacman", kwargs...)
 
-@load joinpath(data_path, "data_triangle_turtle.jld2") xe_turtle TRIS_turtle Const_turtle
+  include("../../data/triangle_turtle.jl")
 export triangle_turtle
 triangle_turtle(; kwargs...) =
   triangle(xe_turtle, TRIS_turtle, Const_turtle; name = "triangle_turtle", kwargs...)


### PR DESCRIPTION
Close #326 

This is an issue we might have as OptimizationProblems grows as well, precompile time will just increase and loading all the necessary data will sometimes crash...