### PR TITLE
fix: discrepancy in problem names.

### DIFF
--- a/src/ADNLPProblems/chnrosnb_mod.jl
+++ b/src/ADNLPProblems/chnrosnb_mod.jl
@@ -8,5 +8,5 @@ function chnrosnb_mod(; n::Int = default_nvar, type::Type{T} = Float64, kwargs..
            sum((1 - x[i])^2 for i = 2:n)
   end
   x0 = -ones(T, n)
-  return ADNLPModels.ADNLPModel(f, x0, name = "chnrosnb"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "chnrosnb_mod"; kwargs...)
 end

--- a/src/ADNLPProblems/errinros_mod.jl
+++ b/src/ADNLPProblems/errinros_mod.jl
@@ -18,7 +18,7 @@ function errinros_mod(
            1 // 2 * sum((1 - x[i])^2 for i = 2:n)
   end
   x0 = -ones(T, n)
-  return ADNLPModels.ADNLPModel(f, x0, name = "errinros"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "errinros_mod"; kwargs...)
 end
 
 function errinros_mod(
@@ -37,5 +37,5 @@ function errinros_mod(
     return r
   end
   x0 = -ones(T, n)
-  return ADNLPModels.ADNLSModel!(F!, x0, 2 * (n - 1), name = "errinros-nls"; kwargs...)
+  return ADNLPModels.ADNLSModel!(F!, x0, 2 * (n - 1), name = "errinros_mod-nls"; kwargs...)
 end

--- a/src/ADNLPProblems/fletcbv3_mod.jl
+++ b/src/ADNLPProblems/fletcbv3_mod.jl
@@ -10,5 +10,5 @@ function fletcbv3_mod(; n::Int = default_nvar, type::Type{T} = Float64, kwargs..
            p * sum(100 * (1 + (2 / h^2)) * sin(x[i] / 100) + (1 / h^2) * cos(x[i]) for i = 1:n)
   end
   x0 = T.([(i / (n + 1)) for i = 1:n])
-  return ADNLPModels.ADNLPModel(f, x0, name = "fletcbv3"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "fletcbv3_mod"; kwargs...)
 end

--- a/src/ADNLPProblems/genrose.jl
+++ b/src/ADNLPProblems/genrose.jl
@@ -12,4 +12,4 @@ function genrose(; n::Int = default_nvar, type::Type{T} = Float64, kwargs...) wh
   return ADNLPModels.ADNLPModel(f, x0, name = "genrose"; kwargs...)
 end
 
-rosenbrock(args...; kwargs...) = genrose(args..., n = 2; delete!(Dict(kwargs), :n)...)
+rosenbrock(args...; kwargs...) = genrose(args..., n = 2, name="rosenbrock"; delete!(Dict(kwargs), :n)...)

--- a/src/ADNLPProblems/indef_mod.jl
+++ b/src/ADNLPProblems/indef_mod.jl
@@ -8,5 +8,5 @@ function indef_mod(; n::Int = default_nvar, type::Type{T} = Float64, kwargs...) 
            1 // 2 * sum(cos(2 * x[i] - x[n] - x[1]) for i = 2:(n - 1))
   end
   x0 = T.([(i / (n + 1)) for i = 1:n])
-  return ADNLPModels.ADNLPModel(f, x0, name = "indef"; kwargs...)
+  return ADNLPModels.ADNLPModel(f, x0, name = "indef_mod"; kwargs...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,8 @@ include("test_utils.jl")
     eval(Meta.parse("ADNLPProblems.$(prob)(" * simp_backend * ")"))
   end
 
+  @test nlp_ad.meta.name == pb
+
   if pb in meta[(meta.contype .== :quadratic) .| (meta.contype .== :general), :name]
     @testset "Test In-place Nonlinear Constraints for AD-$prob" begin
       test_in_place_constraints(prob, nlp_ad)


### PR DESCRIPTION
Reference #356 

Q: How should I handle the NLS name declared here:
https://github.com/JuliaSmoothOptimizers/OptimizationProblems.jl/blob/59bf416346611e4713d1c49b9c748ad474b9fa91/src/ADNLPProblems/errinros_mod.jl#L40
should it be `errinros_mod_nls` or `errinros-mod-nls` or `errinros_mod-nls`? 
