### PR TITLE
Update compat versions for DataFrames and JLD2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-DataFrames = "1"
-JLD2 = "0.4"
+DataFrames = "^1"
+JLD2 = "^0.4"
 JuMP = "^1.15"
 Requires = "1"
 SpecialFunctions = "2"


### PR DESCRIPTION

Changed the compatibility entries for `DataFrames` and `JLD2` in `Project.toml` to use caret (`^`) syntax. This allows for more flexible version resolution within the same major version, reducing potential package conflicts and improving compatibility with other dependencies.

**Changes:**

* `DataFrames = "1"` → `DataFrames = "^1"`
* `JLD2 = "0.4"` → `JLD2 = "^0.5"`

This update ensures the package works smoothly with newer patch and minor releases of these dependencies.

