### PR TITLE
Support JLD2 v0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,12 +12,12 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-DataFrames = "^1"
-JLD2 = "0.4, 0.5"
+DataFrames = "1"
+JLD2 = "0.5, 0.6"
 JuMP = "^1.15"
 Requires = "1"
 SpecialFunctions = "2"
-julia = "~1"
+julia = "1.6"
 
 [extras]
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"


### PR DESCRIPTION
I also dropped JLD2 v0.4. We don’t use any workflow to test the lowest compat entry, so we’re less prone to errors if we do that.

I already do that for all JSO packages.