### PR TITLE
Implementation field

### DIFF
--- a/.claude/skills/review-meta/SKILL.md
+++ b/.claude/skills/review-meta/SKILL.md
@@ -74,6 +74,7 @@ Scan the text of `src/Meta/<name>.jl` and collect findings under three severity 
 | `:is_feasible` | `true`, `false`, or `missing` |
 | `:defined_everywhere` | `true`, `false`, or `missing` |
 | `:origin` | One of `:academic :modelling :real :unknown` |
+| `:implementation` | One of `:both :jump :adnlpmodels` — must match which sibling files exist: `:both` if both `src/ADNLPProblems/<name>.jl` and `src/PureJuMP/<name>.jl` exist, `:jump` if only PureJuMP, `:adnlpmodels` if only ADNLPProblems |
 | `:url` | String — empty string `""` is OK; if non-empty, every comma-separated part must match `^https?://[^\s/$.?#][^\s]*$` (case-insensitive) |
 | `:notes` | Any string (raw strings allowed) |
 | `:origin_notes` | Any string (raw strings allowed) |

--- a/.claude/skills/review-purejump/SKILL.md
+++ b/.claude/skills/review-purejump/SKILL.md
@@ -81,7 +81,7 @@ Scan the text of `src/PureJuMP/<name>.jl` and collect findings under three sever
 - [ ] Multi-function file: the `export` statement lists more than one symbol. This is an accepted legacy pattern for function families (dixmaan, genrose+rosenbrock, triangle variants) but new problems should not use it.
 - [ ] `n::Int = default_nvar` is present in the signature but `n` is not used in the body. This is harmless but misleading — the keyword will be silently ignored.
 - [ ] Data-loading file: calls `_ensure_data!` or `include("../../data/...")`. Correct pattern for mesh/tabular problems; means the problem is effectively non-scalable.
-- [ ] `src/ADNLPProblems/<name>.jl` does not exist. This is a JuMP-only problem. Verify it is in the known exclusion list (`catmix`, `gasoil`, `glider`, `methanol`, `minsurf`, `pinene`, `rocket`, `steering`, `torsion`). If it is not in that list, flag as **Warning** — the test suite will fail to find the ADNLPProblems implementation.
+- [ ] `src/ADNLPProblems/<name>.jl` does not exist. This is a JuMP-only problem. Check that `src/Meta/<name>.jl` has `:implementation => :jump`. If it has `:both` or `:adnlpmodels` instead, flag as **Error** — the test suite consistency check will fail.
 - [ ] `src/Meta/<name>.jl` does not exist. Without a meta file the problem is absent from `OptimizationProblems.meta`, and the test `sort(list_problems) == sort(Symbol.(meta[!, :name]))` will fail. This is an **Error**.
 
 ### Step 4 — Dynamic analysis (run Julia)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Metadata dictionary. Does **not** export the problem function.
   :is_feasible           => true,
   :defined_everywhere    => true,
   :origin                => :academic,    # see valid values below
+  :implementation        => :both,        # see valid values below
   # Additional fields (branch move-docstring-to-metadata):
   :url            => "https://...",       # must match ^https?://
   :notes          => raw"""""",           # problem description
@@ -107,6 +108,7 @@ Metadata dictionary. Does **not** export the problem function.
 - `:objtype`: `:none`, `:constant`, `:linear`, `:quadratic`, `:sum_of_squares`, `:other`, `:least_squares`
 - `:contype`: `:unconstrained`, `:linear`, `:quadratic`, `:general`
 - `:origin`: `:academic`, `:modelling`, `:real`, `:unknown`
+- `:implementation`: `:both`, `:jump`, `:adnlpmodels`
 
 ---
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -110,6 +110,7 @@ See existing NLS problems (e.g., [`lanczos1`](https://github.com/JuliaSmoothOpti
 **Meta**
 - [ ] The corresponding meta file exists (`src/Meta/problem_name.jl`), the problem name matches the AD and JuMP files, and `OptimizationProblems.meta` contains the problem entry.
 - [ ] All meta fields (origin, objtype, contype, bounds, best-known, etc.) are filled correctly.
+- [ ] `:implementation` is set correctly: `:both` if both `ADNLPProblems` and `PureJuMP` files exist, `:jump` if only `PureJuMP`, `:adnlpmodels` if only `ADNLPProblems`.
 - [ ] All six getter functions (`get_<name>_nvar`, `get_<name>_ncon`, `get_<name>_nlin`, `get_<name>_nnln`, `get_<name>_nequ`, `get_<name>_nineq`) are defined in the meta file (required for every problem, not only scalable ones).
 - [ ] The problem origin/provenance is clearly documented and consistent between the `PureJuMP` problem documentation and the `:origin` meta entry.
 - [ ] Meta formulas for variable sizes match actual model behavior.

--- a/docs/src/meta.md
+++ b/docs/src/meta.md
@@ -51,6 +51,21 @@ adproblems = (
 )
 ```
 
+### Implementation availability (`:implementation`)
+
+The `:implementation` column records which modelling backends provide the problem:
+
+| Value | Meaning |
+|-------|---------|
+| `:both` | Available in both `ADNLPProblems` and `PureJuMP` |
+| `:jump` | `PureJuMP` only |
+| `:adnlpmodels` | `ADNLPProblems` only |
+
+```@example 1
+meta = OptimizationProblems.meta
+both_problems = meta[meta.implementation .== :both, [:name, :implementation]]
+```
+
 ### Nonlinear Least Squares Problems (NLS) 
 Problems with `:objtype` set to `:least_squares` are nonlinear least squares problems (NLS). For these, you can access the number of NLS equations using a getter like `get_nameoftheproblem_nls_nequ()`.
 ```@example 1

--- a/src/Meta/AMPGO02.jl
+++ b/src/Meta/AMPGO02.jl
@@ -16,6 +16,7 @@ AMPGO02_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO03.jl
+++ b/src/Meta/AMPGO03.jl
@@ -16,6 +16,7 @@ AMPGO03_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO04.jl
+++ b/src/Meta/AMPGO04.jl
@@ -16,6 +16,7 @@ AMPGO04_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO05.jl
+++ b/src/Meta/AMPGO05.jl
@@ -16,6 +16,7 @@ AMPGO05_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO06.jl
+++ b/src/Meta/AMPGO06.jl
@@ -16,6 +16,7 @@ AMPGO06_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO07.jl
+++ b/src/Meta/AMPGO07.jl
@@ -16,6 +16,7 @@ AMPGO07_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO08.jl
+++ b/src/Meta/AMPGO08.jl
@@ -16,6 +16,7 @@ AMPGO08_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO09.jl
+++ b/src/Meta/AMPGO09.jl
@@ -16,6 +16,7 @@ AMPGO09_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO10.jl
+++ b/src/Meta/AMPGO10.jl
@@ -16,6 +16,7 @@ AMPGO10_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO11.jl
+++ b/src/Meta/AMPGO11.jl
@@ -16,6 +16,7 @@ AMPGO11_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO12.jl
+++ b/src/Meta/AMPGO12.jl
@@ -16,6 +16,7 @@ AMPGO12_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO13.jl
+++ b/src/Meta/AMPGO13.jl
@@ -16,6 +16,7 @@ AMPGO13_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO14.jl
+++ b/src/Meta/AMPGO14.jl
@@ -16,6 +16,7 @@ AMPGO14_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO15.jl
+++ b/src/Meta/AMPGO15.jl
@@ -16,6 +16,7 @@ AMPGO15_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO18.jl
+++ b/src/Meta/AMPGO18.jl
@@ -16,6 +16,7 @@ AMPGO18_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO20.jl
+++ b/src/Meta/AMPGO20.jl
@@ -16,6 +16,7 @@ AMPGO20_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO21.jl
+++ b/src/Meta/AMPGO21.jl
@@ -16,6 +16,7 @@ AMPGO21_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/AMPGO22.jl
+++ b/src/Meta/AMPGO22.jl
@@ -16,6 +16,7 @@ AMPGO22_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://infinity77.net/global_optimization/test_functions_1d.html#d-test-functions",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/BOX2.jl
+++ b/src/Meta/BOX2.jl
@@ -16,6 +16,7 @@ BOX2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BOX2.SIF",
   :notes => raw"""
 Box problem in 2 variables, obtained by fixing X3 = 1 in BOX2.

--- a/src/Meta/BOX3.jl
+++ b/src/Meta/BOX3.jl
@@ -16,6 +16,7 @@ BOX3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BOX3.SIF",
   :notes => raw"""
 SIF input: Ph. Toint, Dec 1989.

--- a/src/Meta/Dus2_1.jl
+++ b/src/Meta/Dus2_1.jl
@@ -16,6 +16,7 @@ Dus2_1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.dmi.usherb.ca/~dussault/ROP630E17/",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/Dus2_3.jl
+++ b/src/Meta/Dus2_3.jl
@@ -16,6 +16,7 @@ Dus2_3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.dmi.usherb.ca/~dussault/ROP630E17/",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/Dus2_9.jl
+++ b/src/Meta/Dus2_9.jl
@@ -16,6 +16,7 @@ Dus2_9_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.dmi.usherb.ca/~dussault/ROP630E17/",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/Duscube.jl
+++ b/src/Meta/Duscube.jl
@@ -16,6 +16,7 @@ Duscube_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.dmi.usherb.ca/~dussault/ROP630E17/",
   :notes => raw"""
 A one dimensional optimization problem

--- a/src/Meta/NZF1.jl
+++ b/src/Meta/NZF1.jl
@@ -16,6 +16,7 @@ NZF1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1080/10556780500137116",
   :notes => raw"""
 "Philippe Toint (private communication)"

--- a/src/Meta/Shpak1.jl
+++ b/src/Meta/Shpak1.jl
@@ -16,6 +16,7 @@ Shpak1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.math.md/publications/csjm/issues/v3-n2/7902/",
   :notes => raw"""
 first problem of

--- a/src/Meta/Shpak2.jl
+++ b/src/Meta/Shpak2.jl
@@ -16,6 +16,7 @@ Shpak2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.math.md/publications/csjm/issues/v3-n2/7902/",
   :notes => raw"""
 Second problem of

--- a/src/Meta/Shpak3.jl
+++ b/src/Meta/Shpak3.jl
@@ -16,6 +16,7 @@ Shpak3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.math.md/publications/csjm/issues/v3-n2/7902/",
   :notes => raw"""
 third problem of

--- a/src/Meta/Shpak4.jl
+++ b/src/Meta/Shpak4.jl
@@ -16,6 +16,7 @@ Shpak4_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.math.md/publications/csjm/issues/v3-n2/7902/",
   :notes => raw"""
 4th problem of

--- a/src/Meta/Shpak5.jl
+++ b/src/Meta/Shpak5.jl
@@ -16,6 +16,7 @@ Shpak5_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.math.md/publications/csjm/issues/v3-n2/7902/",
   :notes => raw"""
 fifth problem of

--- a/src/Meta/Shpak6.jl
+++ b/src/Meta/Shpak6.jl
@@ -16,6 +16,7 @@ Shpak6_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.math.md/publications/csjm/issues/v3-n2/7902/",
   :notes => raw"""
 6th problem of

--- a/src/Meta/aircrfta.jl
+++ b/src/Meta/aircrfta.jl
@@ -16,6 +16,7 @@ aircrfta_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://www.osti.gov/biblio/6449249, https://bitbucket.org/optrove/sif/src/master/AIRCRFTA.SIF",
   :notes => raw"""
 The aircraft stability problem by Rheinboldt, as a function

--- a/src/Meta/allinit.jl
+++ b/src/Meta/allinit.jl
@@ -16,6 +16,7 @@ allinit_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ALLINIT.SIF",
   :notes => raw"""
 A problem with "all in it". Intended to verify that changes

--- a/src/Meta/allinitc.jl
+++ b/src/Meta/allinitc.jl
@@ -16,6 +16,7 @@ allinitc_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ALLINITC.SIF",
   :notes => raw"""
 A problem with "all in it". Intended to verify that changes

--- a/src/Meta/allinitu.jl
+++ b/src/Meta/allinitu.jl
@@ -16,6 +16,7 @@ allinitu_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ALLINITU.SIF",
   :notes => raw"""
 A problem with "all in it". Intended to verify that changes

--- a/src/Meta/alsotame.jl
+++ b/src/Meta/alsotame.jl
@@ -16,6 +16,7 @@ alsotame_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ALSOTAME.SIF",
   :notes => raw"""
 Another simple constrained  problem

--- a/src/Meta/argauss.jl
+++ b/src/Meta/argauss.jl
@@ -16,6 +16,7 @@ argauss_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1145/355934.355936, https://bitbucket.org/optrove/sif/src/master/ARGAUSS.SIF",
   :notes => raw"""
 SIF input: Ph. Toint, Dec 1989.

--- a/src/Meta/arglina.jl
+++ b/src/Meta/arglina.jl
@@ -16,6 +16,7 @@ arglina_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1145/355934.355936, https://bitbucket.org/optrove/sif/src/master/ARGLINA.SIF",
   :notes => raw"""
 Linear function - full rank

--- a/src/Meta/arglinb.jl
+++ b/src/Meta/arglinb.jl
@@ -16,6 +16,7 @@ arglinb_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1145/355934.355936, https://bitbucket.org/optrove/sif/src/master/ARGLINB.SIF",
   :notes => raw"""
 Linear function - rank 1

--- a/src/Meta/arglinc.jl
+++ b/src/Meta/arglinc.jl
@@ -16,6 +16,7 @@ arglinc_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1145/355934.355936, https://bitbucket.org/optrove/sif/src/master/ARGLINC.SIF",
   :notes => raw"""
 Linear function - rank 1, zero columns and rows

--- a/src/Meta/argtrig.jl
+++ b/src/Meta/argtrig.jl
@@ -16,6 +16,7 @@ argtrig_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1145/355934.355936, https://bitbucket.org/optrove/sif/src/master/ARGTRIG.SIF",
   :notes => raw"""
 Variable dimension trigonometric problem

--- a/src/Meta/arwhead.jl
+++ b/src/Meta/arwhead.jl
@@ -16,6 +16,7 @@ arwhead_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/ARWHEAD.SIF",
   :notes => raw"""
 Arrow head problem.

--- a/src/Meta/auglag.jl
+++ b/src/Meta/auglag.jl
@@ -16,6 +16,7 @@ auglag_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Augmented Lagrangian function

--- a/src/Meta/avion2.jl
+++ b/src/Meta/avion2.jl
@@ -16,6 +16,7 @@ avion2_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/AVION2.SIF",
   :notes => raw"""
 Dassault France avion (airplane design) problem

--- a/src/Meta/bard.jl
+++ b/src/Meta/bard.jl
@@ -16,6 +16,7 @@ bard_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BARD.SIF",
   :notes => raw"""
 Bard problem in 3 variables.

--- a/src/Meta/bdqrtic.jl
+++ b/src/Meta/bdqrtic.jl
@@ -16,6 +16,7 @@ bdqrtic_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BDQRTIC.SIF",
   :notes => raw"""
 This problem is quartic and has a banded Hessian with bandwidth = 9

--- a/src/Meta/beale.jl
+++ b/src/Meta/beale.jl
@@ -16,6 +16,7 @@ beale_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BEALE.SIF",
   :notes => raw"""
 Beale problem in 2 variables

--- a/src/Meta/bearing.jl
+++ b/src/Meta/bearing.jl
@@ -16,6 +16,7 @@ bearing_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Given observations of ns stages of a bearing species over n timesteps, 

--- a/src/Meta/bennett5.jl
+++ b/src/Meta/bennett5.jl
@@ -16,6 +16,7 @@ bennett5_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BENNETT5.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/bennett5.dat

--- a/src/Meta/biggs5.jl
+++ b/src/Meta/biggs5.jl
@@ -16,6 +16,7 @@ biggs5_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BIGGS5.SIF",
   :notes => raw"""
 Biggs problem in 5 variables.

--- a/src/Meta/biggs6.jl
+++ b/src/Meta/biggs6.jl
@@ -16,6 +16,7 @@ biggs6_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BIGGS6.SIF",
   :notes => raw"""
 Biggs EXP problem in 6 variables

--- a/src/Meta/booth.jl
+++ b/src/Meta/booth.jl
@@ -16,6 +16,7 @@ booth_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BOOTH.SIF",
   :notes => raw"""
 SIF input: Ph. Toint, Dec 1989.

--- a/src/Meta/boundary.jl
+++ b/src/Meta/boundary.jl
@@ -16,6 +16,7 @@ boundary_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Discrete boundary value problem

--- a/src/Meta/boxbod.jl
+++ b/src/Meta/boxbod.jl
@@ -16,6 +16,7 @@ boxbod_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BOXBOD.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/boxbod.dat

--- a/src/Meta/bqp1var.jl
+++ b/src/Meta/bqp1var.jl
@@ -16,6 +16,7 @@ bqp1var_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BQP1VAR.SIF",
   :notes => raw"""
 classification QBR2-AN-1-0

--- a/src/Meta/britgas.jl
+++ b/src/Meta/britgas.jl
@@ -16,6 +16,7 @@ britgas_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BRITGAS.SIF",
   :notes => raw"""
 A simple high pressure gas network problem for British Gas.

--- a/src/Meta/brownal.jl
+++ b/src/Meta/brownal.jl
@@ -16,6 +16,7 @@ brownal_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BROWNAL.SIF",
   :notes => raw"""
 The Brown almost linear problem in variable dimension.  This is a nonlinear

--- a/src/Meta/brownbs.jl
+++ b/src/Meta/brownbs.jl
@@ -16,6 +16,7 @@ brownbs_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BROWNBS.SIF",
   :notes => raw"""
 Brown badly scaled problem in 2 variables.

--- a/src/Meta/brownden.jl
+++ b/src/Meta/brownden.jl
@@ -16,6 +16,7 @@ brownden_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BROWNDEN.SIF",
   :notes => raw"""
 Brown and Dennis function

--- a/src/Meta/browngen1.jl
+++ b/src/Meta/browngen1.jl
@@ -16,6 +16,7 @@ browngen1_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Generalization of the Brown function 1

--- a/src/Meta/browngen2.jl
+++ b/src/Meta/browngen2.jl
@@ -16,6 +16,7 @@ browngen2_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Generalization of the Brown function 2

--- a/src/Meta/broyden3d.jl
+++ b/src/Meta/broyden3d.jl
@@ -16,6 +16,7 @@ broyden3d_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1145/355934.355936",
   :notes => raw"""
 Broyden tridiagonal problem in variable dimension.  This is a nonlinear

--- a/src/Meta/broyden7d.jl
+++ b/src/Meta/broyden7d.jl
@@ -16,6 +16,7 @@ broyden7d_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Seven diagonal generalization of the Broyden tridiagonal function

--- a/src/Meta/broydn7d.jl
+++ b/src/Meta/broydn7d.jl
@@ -16,6 +16,7 @@ broydn7d_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BROYDN7D.SIF",
   :notes => raw"""
 A seven diagonal variant of the Broyden tridiagonal system,

--- a/src/Meta/brybnd.jl
+++ b/src/Meta/brybnd.jl
@@ -16,6 +16,7 @@ brybnd_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BRYBND.SIF",
   :notes => raw"""
 Broyden banded system of nonlinear equations, considered in the

--- a/src/Meta/bt1.jl
+++ b/src/Meta/bt1.jl
@@ -16,6 +16,7 @@ bt1_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/BT1.SIF",
   :notes => raw"""
 classification QQR2-AN-2-1

--- a/src/Meta/camshape.jl
+++ b/src/Meta/camshape.jl
@@ -16,6 +16,7 @@ camshape_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CAMSHAPE.SIF",
   :notes => raw"""
 Maximize the area of the valve opening for one rotation of a convex cam 

--- a/src/Meta/catenary.jl
+++ b/src/Meta/catenary.jl
@@ -16,6 +16,7 @@ catenary_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CATENARY.SIF",
   :notes => raw"""
 The classical problem of the hanging catenary.  Here the catenary consists

--- a/src/Meta/catmix.jl
+++ b/src/Meta/catmix.jl
@@ -16,6 +16,7 @@ catmix_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://bitbucket.org/optrove/sif/src/master/CATMIX.SIF",
   :notes => raw"""
 Catalyst Mixing Problem

--- a/src/Meta/chain.jl
+++ b/src/Meta/chain.jl
@@ -16,6 +16,7 @@ chain_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CHAIN.SIF",
   :notes => raw"""
 Hanging Chain

--- a/src/Meta/chainwoo.jl
+++ b/src/Meta/chainwoo.jl
@@ -16,6 +16,7 @@ chainwoo_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CHAINWOO.SIF",
   :notes => raw"""
 The chained Woods problem, a variant on Woods function

--- a/src/Meta/channel.jl
+++ b/src/Meta/channel.jl
@@ -16,6 +16,7 @@ channel_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CHANNEL.SIF",
   :notes => raw"""
 Flow in a Channel

--- a/src/Meta/chnrosnb_mod.jl
+++ b/src/Meta/chnrosnb_mod.jl
@@ -16,6 +16,7 @@ chnrosnb_mod_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 # Chaineded Rosenbrock - modified function.

--- a/src/Meta/chwirut1.jl
+++ b/src/Meta/chwirut1.jl
@@ -16,6 +16,7 @@ chwirut1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CHWIRUT1.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/chwirut1.dat

--- a/src/Meta/chwirut2.jl
+++ b/src/Meta/chwirut2.jl
@@ -16,6 +16,7 @@ chwirut2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CHWIRUT2.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/chwirut2.dat

--- a/src/Meta/cliff.jl
+++ b/src/Meta/cliff.jl
@@ -16,6 +16,7 @@ cliff_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CLIFF.SIF",
   :notes => raw"""
 The "cliff problem" in 2 variables

--- a/src/Meta/clnlbeam.jl
+++ b/src/Meta/clnlbeam.jl
@@ -16,6 +16,7 @@ clnlbeam_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://onlinelibrary.wiley.com/doi/abs/10.1002/oca.4660120103, https://bitbucket.org/optrove/sif/src/master/CLNLBEAM.SIF",
   :notes => raw"""
 The clnlbeam problem

--- a/src/Meta/clplatea.jl
+++ b/src/Meta/clplatea.jl
@@ -16,6 +16,7 @@ clplatea_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CLPLATEA.SIF",
   :notes => raw"""
 The clamped plate problem (Strang, Nocedal, Dax).

--- a/src/Meta/clplateb.jl
+++ b/src/Meta/clplateb.jl
@@ -16,6 +16,7 @@ clplateb_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CLPLATEB.SIF",
   :notes => raw"""
 The clamped plate problem (Strang, Nocedal, Dax)

--- a/src/Meta/clplatec.jl
+++ b/src/Meta/clplatec.jl
@@ -16,6 +16,7 @@ clplatec_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CLPLATEC.SIF",
   :notes => raw"""
 The clamped plate problem (Strang, Nocedal, Dax).

--- a/src/Meta/controlinvestment.jl
+++ b/src/Meta/controlinvestment.jl
@@ -16,6 +16,7 @@ controlinvestment_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "",
   :notes => raw"""
 This is a simple investment problem in optimistic market.

--- a/src/Meta/cosine.jl
+++ b/src/Meta/cosine.jl
@@ -16,6 +16,7 @@ cosine_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/COSINE.SIF",
   :notes => raw"""
 The cosine function.

--- a/src/Meta/cragglvy.jl
+++ b/src/Meta/cragglvy.jl
@@ -16,6 +16,7 @@ cragglvy_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CRAGGLVY.SIF",
   :notes => raw"""
 Extended Cragg and Levy problem.

--- a/src/Meta/cragglvy2.jl
+++ b/src/Meta/cragglvy2.jl
@@ -16,6 +16,7 @@ cragglvy2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Chained Cragg and Levy function

--- a/src/Meta/curly.jl
+++ b/src/Meta/curly.jl
@@ -16,6 +16,7 @@ curly_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 A banded function with semi-bandwidth b and

--- a/src/Meta/curly10.jl
+++ b/src/Meta/curly10.jl
@@ -16,6 +16,7 @@ curly10_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :adnlpmodels,
   :url => "https://bitbucket.org/optrove/sif/src/master/CURLY10.SIF",
   :notes => raw"""
 A banded function with semi-bandwidth b and

--- a/src/Meta/curly10.jl
+++ b/src/Meta/curly10.jl
@@ -16,7 +16,7 @@ curly10_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
-  :implementation => :adnlpmodels,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CURLY10.SIF",
   :notes => raw"""
 A banded function with semi-bandwidth b and

--- a/src/Meta/curly20.jl
+++ b/src/Meta/curly20.jl
@@ -16,6 +16,7 @@ curly20_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :adnlpmodels,
   :url => "https://bitbucket.org/optrove/sif/src/master/CURLY20.SIF",
   :notes => raw"""
 A banded function with semi-bandwidth b and

--- a/src/Meta/curly20.jl
+++ b/src/Meta/curly20.jl
@@ -16,7 +16,7 @@ curly20_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
-  :implementation => :adnlpmodels,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CURLY20.SIF",
   :notes => raw"""
 A banded function with semi-bandwidth b and

--- a/src/Meta/curly30.jl
+++ b/src/Meta/curly30.jl
@@ -16,6 +16,7 @@ curly30_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :adnlpmodels,
   :url => "https://bitbucket.org/optrove/sif/src/master/CURLY30.SIF",
   :notes => raw"""
 A banded function with semi-bandwidth b and

--- a/src/Meta/curly30.jl
+++ b/src/Meta/curly30.jl
@@ -16,7 +16,7 @@ curly30_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
-  :implementation => :adnlpmodels,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/CURLY30.SIF",
   :notes => raw"""
 A banded function with semi-bandwidth b and

--- a/src/Meta/danwood.jl
+++ b/src/Meta/danwood.jl
@@ -16,6 +16,7 @@ danwood_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/danwood.dat, https://bitbucket.org/optrove/sif/src/master/DANWOOD.SIF",
   :notes => raw"""
 NIST/ITL StRD

--- a/src/Meta/dixmaane.jl
+++ b/src/Meta/dixmaane.jl
@@ -16,6 +16,7 @@ dixmaane_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 The Dixon-Maany test problem (version E by default)

--- a/src/Meta/dixmaanf.jl
+++ b/src/Meta/dixmaanf.jl
@@ -16,6 +16,7 @@ dixmaanf_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANF.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version E by default)

--- a/src/Meta/dixmaang.jl
+++ b/src/Meta/dixmaang.jl
@@ -16,6 +16,7 @@ dixmaang_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANG.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version E by default)

--- a/src/Meta/dixmaanh.jl
+++ b/src/Meta/dixmaanh.jl
@@ -16,6 +16,7 @@ dixmaanh_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANH.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version E by default)

--- a/src/Meta/dixmaani.jl
+++ b/src/Meta/dixmaani.jl
@@ -16,6 +16,7 @@ dixmaani_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 The Dixon-Maany test problem (version I by default)

--- a/src/Meta/dixmaanj.jl
+++ b/src/Meta/dixmaanj.jl
@@ -16,6 +16,7 @@ dixmaanj_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANJ.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version I by default)

--- a/src/Meta/dixmaank.jl
+++ b/src/Meta/dixmaank.jl
@@ -16,6 +16,7 @@ dixmaank_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANK.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version I by default)

--- a/src/Meta/dixmaanl.jl
+++ b/src/Meta/dixmaanl.jl
@@ -16,6 +16,7 @@ dixmaanl_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANL.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version I by default)

--- a/src/Meta/dixmaanm.jl
+++ b/src/Meta/dixmaanm.jl
@@ -16,6 +16,7 @@ dixmaanm_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 The Dixon-Maany test problem (version M by default)

--- a/src/Meta/dixmaann.jl
+++ b/src/Meta/dixmaann.jl
@@ -16,6 +16,7 @@ dixmaann_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANN.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version M by default)

--- a/src/Meta/dixmaano.jl
+++ b/src/Meta/dixmaano.jl
@@ -16,6 +16,7 @@ dixmaano_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANO.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version M by default)

--- a/src/Meta/dixmaanp.jl
+++ b/src/Meta/dixmaanp.jl
@@ -16,6 +16,7 @@ dixmaanp_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DIXMAANP.SIF",
   :notes => raw"""
 The Dixon-Maany test problem (version M by default)

--- a/src/Meta/dixon3dq.jl
+++ b/src/Meta/dixon3dq.jl
@@ -16,6 +16,7 @@ dixon3dq_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/DIXON3DQ.SIF",
   :notes => raw"""
 Dixon's tridiagonal quadratic.

--- a/src/Meta/dqdrtic.jl
+++ b/src/Meta/dqdrtic.jl
@@ -16,6 +16,7 @@ dqdrtic_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/DQDRTIC.SIF",
   :notes => raw"""
 Diagonal quadratic problem

--- a/src/Meta/dqrtic.jl
+++ b/src/Meta/dqrtic.jl
@@ -16,6 +16,7 @@ dqrtic_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/DQRTIC.SIF",
   :notes => raw"""
 Variable dimension diagonal quartic problem.

--- a/src/Meta/eckerle4.jl
+++ b/src/Meta/eckerle4.jl
@@ -16,6 +16,7 @@ eckerle4_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ECKERLE4.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/eckerle4.dat

--- a/src/Meta/edensch.jl
+++ b/src/Meta/edensch.jl
@@ -16,6 +16,7 @@ edensch_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/EDENSCH.SIF",
   :notes => raw"""
 The extended Dennis and Schnabel problem, as defined by Li.

--- a/src/Meta/eg2.jl
+++ b/src/Meta/eg2.jl
@@ -16,6 +16,7 @@ eg2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/EG2.SIF",
   :notes => raw"""
 A simple nonlinear problem given as an example in Section 1.2.4 of

--- a/src/Meta/elec.jl
+++ b/src/Meta/elec.jl
@@ -16,6 +16,7 @@ elec_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ELEC.SIF",
   :notes => raw"""
 Given np electrons, find the equilibrium state distribution of minimal

--- a/src/Meta/engval1.jl
+++ b/src/Meta/engval1.jl
@@ -16,6 +16,7 @@ engval1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ENGVAL1.SIF",
   :notes => raw"""
 The ENGVAL1 problem.

--- a/src/Meta/enso.jl
+++ b/src/Meta/enso.jl
@@ -16,6 +16,7 @@ enso_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ENSO.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/enso.dat

--- a/src/Meta/errinros_mod.jl
+++ b/src/Meta/errinros_mod.jl
@@ -16,6 +16,7 @@ errinros_mod_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 Errin Rosenbrock - modified function.

--- a/src/Meta/extrosnb.jl
+++ b/src/Meta/extrosnb.jl
@@ -16,6 +16,7 @@ extrosnb_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/EXTROSNB.SIF",
   :notes => raw"""
 The extended Rosenbrock function (nonseparable version).

--- a/src/Meta/fletcbv2.jl
+++ b/src/Meta/fletcbv2.jl
@@ -16,6 +16,7 @@ fletcbv2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/FLETCBV2.SIF",
   :notes => raw"""
 Another Boundary Value problem.

--- a/src/Meta/fletcbv3_mod.jl
+++ b/src/Meta/fletcbv3_mod.jl
@@ -16,6 +16,7 @@ fletcbv3_mod_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 classification OUR2-AN-V-0

--- a/src/Meta/fletchcr.jl
+++ b/src/Meta/fletchcr.jl
@@ -16,6 +16,7 @@ fletchcr_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/FLETCHCR.SIF",
   :notes => raw"""
 The chained Rosenbrock function as given by Fletcher.

--- a/src/Meta/fminsrf2.jl
+++ b/src/Meta/fminsrf2.jl
@@ -16,6 +16,7 @@ fminsrf2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/FMINSRF2.SIF",
   :notes => raw"""
 The free boundary minimum surface problem.

--- a/src/Meta/freuroth.jl
+++ b/src/Meta/freuroth.jl
@@ -16,6 +16,7 @@ freuroth_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/FREUROTH.SIF",
   :notes => raw"""
 The Freudentstein and Roth test problem

--- a/src/Meta/gasoil.jl
+++ b/src/Meta/gasoil.jl
@@ -16,6 +16,7 @@ gasoil_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://bitbucket.org/optrove/sif/src/master/GASOIL.SIF",
   :notes => raw"""
 Catalytic Cracking of Gas Oil Problem

--- a/src/Meta/gauss1.jl
+++ b/src/Meta/gauss1.jl
@@ -16,6 +16,7 @@ gauss1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/GAUSS1.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/gauss1.dat

--- a/src/Meta/gauss2.jl
+++ b/src/Meta/gauss2.jl
@@ -16,6 +16,7 @@ gauss2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/GAUSS2.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/gauss2.dat

--- a/src/Meta/gauss3.jl
+++ b/src/Meta/gauss3.jl
@@ -16,6 +16,7 @@ gauss3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/GAUSS3.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/gauss3.dat

--- a/src/Meta/gaussian.jl
+++ b/src/Meta/gaussian.jl
@@ -16,6 +16,7 @@ gaussian_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/GAUSSIAN.SIF",
   :notes => raw"""
 More''s gaussian problem in 3 variables. This is a nonlinear least-squares

--- a/src/Meta/genbroydenb.jl
+++ b/src/Meta/genbroydenb.jl
@@ -16,6 +16,7 @@ genbroydenb_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Generalized Broyden banded function

--- a/src/Meta/genbroydentri.jl
+++ b/src/Meta/genbroydentri.jl
@@ -16,6 +16,7 @@ genbroydentri_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Generalized Broyden Tridiagonal Function

--- a/src/Meta/genhumps.jl
+++ b/src/Meta/genhumps.jl
@@ -16,6 +16,7 @@ genhumps_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf, https://bitbucket.org/optrove/sif/src/master/GENHUMPS.SIF",
   :notes => raw"""
 A multi-dimensional variant of HUMPS, a two dimensional function

--- a/src/Meta/genrose.jl
+++ b/src/Meta/genrose.jl
@@ -16,6 +16,7 @@ genrose_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/GENROSE.SIF",
   :notes => raw"""
 Generalized Rosenbrock function.

--- a/src/Meta/genrose_nash.jl
+++ b/src/Meta/genrose_nash.jl
@@ -16,6 +16,7 @@ genrose_nash_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 Generalized Rosenbrock function.

--- a/src/Meta/glider.jl
+++ b/src/Meta/glider.jl
@@ -16,6 +16,7 @@ glider_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://bitbucket.org/optrove/sif/src/master/GLIDER.SIF",
   :notes => raw"""
 Hang Glider Problem

--- a/src/Meta/gulf.jl
+++ b/src/Meta/gulf.jl
@@ -16,6 +16,7 @@ gulf_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => false,
   :origin => :real,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/GULF.SIF",
   :notes => raw"""
 The Gulf research and development function for m = 99. 

--- a/src/Meta/hahn1.jl
+++ b/src/Meta/hahn1.jl
@@ -16,6 +16,7 @@ hahn1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/hahn1.dat, https://bitbucket.org/optrove/sif/src/master/HAHN1.SIF",
   :notes => raw"""
 NIST/ITL StRD

--- a/src/Meta/helical.jl
+++ b/src/Meta/helical.jl
@@ -16,6 +16,7 @@ helical_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1145/355934.355936",
   :notes => raw"""
 

--- a/src/Meta/hovercraft1d.jl
+++ b/src/Meta/hovercraft1d.jl
@@ -16,6 +16,7 @@ hovercraft1d_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://laurentlessard.com/teaching/524-intro-to-optimization/",
   :notes => raw"""
 

--- a/src/Meta/hs1.jl
+++ b/src/Meta/hs1.jl
@@ -16,6 +16,7 @@ hs1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS1.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 1.

--- a/src/Meta/hs10.jl
+++ b/src/Meta/hs10.jl
@@ -16,6 +16,7 @@ hs10_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS10.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 10.

--- a/src/Meta/hs100.jl
+++ b/src/Meta/hs100.jl
@@ -16,6 +16,7 @@ hs100_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS100.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 100.

--- a/src/Meta/hs101.jl
+++ b/src/Meta/hs101.jl
@@ -16,6 +16,7 @@ hs101_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS101.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 101.

--- a/src/Meta/hs102.jl
+++ b/src/Meta/hs102.jl
@@ -16,6 +16,7 @@ hs102_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS102.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 102.

--- a/src/Meta/hs103.jl
+++ b/src/Meta/hs103.jl
@@ -16,6 +16,7 @@ hs103_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS103.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 103.

--- a/src/Meta/hs104.jl
+++ b/src/Meta/hs104.jl
@@ -16,6 +16,7 @@ hs104_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS104.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 104.

--- a/src/Meta/hs105.jl
+++ b/src/Meta/hs105.jl
@@ -16,6 +16,7 @@ hs105_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS105.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 105.

--- a/src/Meta/hs106.jl
+++ b/src/Meta/hs106.jl
@@ -16,6 +16,7 @@ hs106_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS106.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 106.

--- a/src/Meta/hs107.jl
+++ b/src/Meta/hs107.jl
@@ -16,6 +16,7 @@ hs107_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS107.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 107.

--- a/src/Meta/hs108.jl
+++ b/src/Meta/hs108.jl
@@ -16,6 +16,7 @@ hs108_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS108.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 108.

--- a/src/Meta/hs109.jl
+++ b/src/Meta/hs109.jl
@@ -16,6 +16,7 @@ hs109_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS109.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 109.

--- a/src/Meta/hs11.jl
+++ b/src/Meta/hs11.jl
@@ -16,6 +16,7 @@ hs11_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS11.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 11.

--- a/src/Meta/hs110.jl
+++ b/src/Meta/hs110.jl
@@ -16,6 +16,7 @@ hs110_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS110.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 110.

--- a/src/Meta/hs111.jl
+++ b/src/Meta/hs111.jl
@@ -16,6 +16,7 @@ hs111_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS111.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 111.

--- a/src/Meta/hs112.jl
+++ b/src/Meta/hs112.jl
@@ -16,6 +16,7 @@ hs112_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS112.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 112.

--- a/src/Meta/hs113.jl
+++ b/src/Meta/hs113.jl
@@ -16,6 +16,7 @@ hs113_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS113.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 113.

--- a/src/Meta/hs114.jl
+++ b/src/Meta/hs114.jl
@@ -16,6 +16,7 @@ hs114_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS114.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 114.

--- a/src/Meta/hs116.jl
+++ b/src/Meta/hs116.jl
@@ -16,6 +16,7 @@ hs116_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS116.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 116.

--- a/src/Meta/hs117.jl
+++ b/src/Meta/hs117.jl
@@ -16,6 +16,7 @@ hs117_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS117.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 117.

--- a/src/Meta/hs118.jl
+++ b/src/Meta/hs118.jl
@@ -16,6 +16,7 @@ hs118_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS118.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 118.

--- a/src/Meta/hs119.jl
+++ b/src/Meta/hs119.jl
@@ -16,6 +16,7 @@ hs119_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS119.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 119.

--- a/src/Meta/hs12.jl
+++ b/src/Meta/hs12.jl
@@ -16,6 +16,7 @@ hs12_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS12.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 12.

--- a/src/Meta/hs13.jl
+++ b/src/Meta/hs13.jl
@@ -16,6 +16,7 @@ hs13_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS13.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 13.

--- a/src/Meta/hs14.jl
+++ b/src/Meta/hs14.jl
@@ -16,6 +16,7 @@ hs14_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS14.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 14.

--- a/src/Meta/hs15.jl
+++ b/src/Meta/hs15.jl
@@ -16,6 +16,7 @@ hs15_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS15.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 15.

--- a/src/Meta/hs16.jl
+++ b/src/Meta/hs16.jl
@@ -16,6 +16,7 @@ hs16_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS16.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 16.

--- a/src/Meta/hs17.jl
+++ b/src/Meta/hs17.jl
@@ -16,6 +16,7 @@ hs17_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS17.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 17.

--- a/src/Meta/hs18.jl
+++ b/src/Meta/hs18.jl
@@ -16,6 +16,7 @@ hs18_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS18.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 18.

--- a/src/Meta/hs19.jl
+++ b/src/Meta/hs19.jl
@@ -16,6 +16,7 @@ hs19_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS19.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 19.

--- a/src/Meta/hs2.jl
+++ b/src/Meta/hs2.jl
@@ -16,6 +16,7 @@ hs2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS2.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 2.

--- a/src/Meta/hs20.jl
+++ b/src/Meta/hs20.jl
@@ -16,6 +16,7 @@ hs20_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS20.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 20.

--- a/src/Meta/hs201.jl
+++ b/src/Meta/hs201.jl
@@ -16,6 +16,7 @@ hs201_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 201.

--- a/src/Meta/hs21.jl
+++ b/src/Meta/hs21.jl
@@ -16,6 +16,7 @@ hs21_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS21.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 21.

--- a/src/Meta/hs211.jl
+++ b/src/Meta/hs211.jl
@@ -16,6 +16,7 @@ hs211_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 211.

--- a/src/Meta/hs219.jl
+++ b/src/Meta/hs219.jl
@@ -16,6 +16,7 @@ hs219_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => true,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 219.

--- a/src/Meta/hs22.jl
+++ b/src/Meta/hs22.jl
@@ -16,6 +16,7 @@ hs22_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS22.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 22.

--- a/src/Meta/hs220.jl
+++ b/src/Meta/hs220.jl
@@ -16,6 +16,7 @@ hs220_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 220.

--- a/src/Meta/hs221.jl
+++ b/src/Meta/hs221.jl
@@ -16,6 +16,7 @@ hs221_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 221.

--- a/src/Meta/hs222.jl
+++ b/src/Meta/hs222.jl
@@ -16,6 +16,7 @@ hs222_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 222.

--- a/src/Meta/hs223.jl
+++ b/src/Meta/hs223.jl
@@ -16,6 +16,7 @@ hs223_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 223.

--- a/src/Meta/hs224.jl
+++ b/src/Meta/hs224.jl
@@ -16,6 +16,7 @@ hs224_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 224.

--- a/src/Meta/hs225.jl
+++ b/src/Meta/hs225.jl
@@ -16,6 +16,7 @@ hs225_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 225.

--- a/src/Meta/hs226.jl
+++ b/src/Meta/hs226.jl
@@ -16,6 +16,7 @@ hs226_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 226.

--- a/src/Meta/hs227.jl
+++ b/src/Meta/hs227.jl
@@ -16,6 +16,7 @@ hs227_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 227.

--- a/src/Meta/hs228.jl
+++ b/src/Meta/hs228.jl
@@ -16,6 +16,7 @@ hs228_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 228.

--- a/src/Meta/hs229.jl
+++ b/src/Meta/hs229.jl
@@ -16,6 +16,7 @@ hs229_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 229.

--- a/src/Meta/hs23.jl
+++ b/src/Meta/hs23.jl
@@ -16,6 +16,7 @@ hs23_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS23.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 23.

--- a/src/Meta/hs230.jl
+++ b/src/Meta/hs230.jl
@@ -16,6 +16,7 @@ hs230_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 230.

--- a/src/Meta/hs231.jl
+++ b/src/Meta/hs231.jl
@@ -16,6 +16,7 @@ hs231_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 231.

--- a/src/Meta/hs232.jl
+++ b/src/Meta/hs232.jl
@@ -16,6 +16,7 @@ hs232_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 232.

--- a/src/Meta/hs233.jl
+++ b/src/Meta/hs233.jl
@@ -16,6 +16,7 @@ hs233_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 233.

--- a/src/Meta/hs234.jl
+++ b/src/Meta/hs234.jl
@@ -16,6 +16,7 @@ hs234_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 234.

--- a/src/Meta/hs235.jl
+++ b/src/Meta/hs235.jl
@@ -16,6 +16,7 @@ hs235_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 235.

--- a/src/Meta/hs236.jl
+++ b/src/Meta/hs236.jl
@@ -16,6 +16,7 @@ hs236_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 236.

--- a/src/Meta/hs237.jl
+++ b/src/Meta/hs237.jl
@@ -16,6 +16,7 @@ hs237_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 237.

--- a/src/Meta/hs238.jl
+++ b/src/Meta/hs238.jl
@@ -16,6 +16,7 @@ hs238_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 238.

--- a/src/Meta/hs239.jl
+++ b/src/Meta/hs239.jl
@@ -16,6 +16,7 @@ hs239_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 239.

--- a/src/Meta/hs24.jl
+++ b/src/Meta/hs24.jl
@@ -16,6 +16,7 @@ hs24_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS24.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 24.

--- a/src/Meta/hs240.jl
+++ b/src/Meta/hs240.jl
@@ -16,6 +16,7 @@ hs240_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 240.

--- a/src/Meta/hs241.jl
+++ b/src/Meta/hs241.jl
@@ -16,6 +16,7 @@ hs241_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 241.

--- a/src/Meta/hs242.jl
+++ b/src/Meta/hs242.jl
@@ -16,6 +16,7 @@ hs242_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 242.

--- a/src/Meta/hs243.jl
+++ b/src/Meta/hs243.jl
@@ -16,6 +16,7 @@ hs243_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 243.

--- a/src/Meta/hs244.jl
+++ b/src/Meta/hs244.jl
@@ -16,6 +16,7 @@ hs244_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 244.

--- a/src/Meta/hs245.jl
+++ b/src/Meta/hs245.jl
@@ -16,6 +16,7 @@ hs245_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 245.

--- a/src/Meta/hs246.jl
+++ b/src/Meta/hs246.jl
@@ -16,6 +16,7 @@ hs246_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 246.

--- a/src/Meta/hs248.jl
+++ b/src/Meta/hs248.jl
@@ -16,6 +16,7 @@ hs248_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 248.

--- a/src/Meta/hs249.jl
+++ b/src/Meta/hs249.jl
@@ -16,6 +16,7 @@ hs249_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 249.

--- a/src/Meta/hs25.jl
+++ b/src/Meta/hs25.jl
@@ -16,6 +16,7 @@ hs25_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS25.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 25.

--- a/src/Meta/hs250.jl
+++ b/src/Meta/hs250.jl
@@ -16,6 +16,7 @@ hs250_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 250.

--- a/src/Meta/hs251.jl
+++ b/src/Meta/hs251.jl
@@ -16,6 +16,7 @@ hs251_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 251.

--- a/src/Meta/hs252.jl
+++ b/src/Meta/hs252.jl
@@ -16,6 +16,7 @@ hs252_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 252.

--- a/src/Meta/hs253.jl
+++ b/src/Meta/hs253.jl
@@ -16,6 +16,7 @@ hs253_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 253.

--- a/src/Meta/hs254.jl
+++ b/src/Meta/hs254.jl
@@ -16,6 +16,7 @@ hs254_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 254.

--- a/src/Meta/hs255.jl
+++ b/src/Meta/hs255.jl
@@ -16,6 +16,7 @@ hs255_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 255.

--- a/src/Meta/hs256.jl
+++ b/src/Meta/hs256.jl
@@ -16,6 +16,7 @@ hs256_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 256.

--- a/src/Meta/hs257.jl
+++ b/src/Meta/hs257.jl
@@ -16,6 +16,7 @@ hs257_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 257.

--- a/src/Meta/hs258.jl
+++ b/src/Meta/hs258.jl
@@ -16,6 +16,7 @@ hs258_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 258.

--- a/src/Meta/hs259.jl
+++ b/src/Meta/hs259.jl
@@ -16,6 +16,7 @@ hs259_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 259.

--- a/src/Meta/hs26.jl
+++ b/src/Meta/hs26.jl
@@ -16,6 +16,7 @@ hs26_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS26.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 26.

--- a/src/Meta/hs260.jl
+++ b/src/Meta/hs260.jl
@@ -16,6 +16,7 @@ hs260_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 260.

--- a/src/Meta/hs261.jl
+++ b/src/Meta/hs261.jl
@@ -16,6 +16,7 @@ hs261_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 261.

--- a/src/Meta/hs262.jl
+++ b/src/Meta/hs262.jl
@@ -16,6 +16,7 @@ hs262_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 262.

--- a/src/Meta/hs263.jl
+++ b/src/Meta/hs263.jl
@@ -16,6 +16,7 @@ hs263_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 263.

--- a/src/Meta/hs264.jl
+++ b/src/Meta/hs264.jl
@@ -16,6 +16,7 @@ hs264_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 264.

--- a/src/Meta/hs265.jl
+++ b/src/Meta/hs265.jl
@@ -16,6 +16,7 @@ hs265_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Hock and Schittkowski problem number 265.

--- a/src/Meta/hs27.jl
+++ b/src/Meta/hs27.jl
@@ -16,6 +16,7 @@ hs27_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS27.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 27.

--- a/src/Meta/hs28.jl
+++ b/src/Meta/hs28.jl
@@ -16,6 +16,7 @@ hs28_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS28.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 28.

--- a/src/Meta/hs29.jl
+++ b/src/Meta/hs29.jl
@@ -16,6 +16,7 @@ hs29_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS29.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 29.

--- a/src/Meta/hs3.jl
+++ b/src/Meta/hs3.jl
@@ -16,6 +16,7 @@ hs3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS3.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 3.

--- a/src/Meta/hs30.jl
+++ b/src/Meta/hs30.jl
@@ -16,6 +16,7 @@ hs30_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS30.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 30.

--- a/src/Meta/hs31.jl
+++ b/src/Meta/hs31.jl
@@ -16,6 +16,7 @@ hs31_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS31.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 31.

--- a/src/Meta/hs316.jl
+++ b/src/Meta/hs316.jl
@@ -16,6 +16,7 @@ hs316_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 316.

--- a/src/Meta/hs317.jl
+++ b/src/Meta/hs317.jl
@@ -16,6 +16,7 @@ hs317_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 317.

--- a/src/Meta/hs318.jl
+++ b/src/Meta/hs318.jl
@@ -16,6 +16,7 @@ hs318_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 318.

--- a/src/Meta/hs319.jl
+++ b/src/Meta/hs319.jl
@@ -16,6 +16,7 @@ hs319_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 319.

--- a/src/Meta/hs32.jl
+++ b/src/Meta/hs32.jl
@@ -16,6 +16,7 @@ hs32_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS32.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 32.

--- a/src/Meta/hs320.jl
+++ b/src/Meta/hs320.jl
@@ -16,6 +16,7 @@ hs320_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 320.

--- a/src/Meta/hs321.jl
+++ b/src/Meta/hs321.jl
@@ -16,6 +16,7 @@ hs321_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 321.

--- a/src/Meta/hs322.jl
+++ b/src/Meta/hs322.jl
@@ -16,6 +16,7 @@ hs322_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 322.

--- a/src/Meta/hs33.jl
+++ b/src/Meta/hs33.jl
@@ -16,6 +16,7 @@ hs33_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS33.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 33.

--- a/src/Meta/hs34.jl
+++ b/src/Meta/hs34.jl
@@ -16,6 +16,7 @@ hs34_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS34.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 34.

--- a/src/Meta/hs35.jl
+++ b/src/Meta/hs35.jl
@@ -16,6 +16,7 @@ hs35_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS35.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 35.

--- a/src/Meta/hs36.jl
+++ b/src/Meta/hs36.jl
@@ -16,6 +16,7 @@ hs36_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS36.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 36.

--- a/src/Meta/hs37.jl
+++ b/src/Meta/hs37.jl
@@ -16,6 +16,7 @@ hs37_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS37.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 37.

--- a/src/Meta/hs378.jl
+++ b/src/Meta/hs378.jl
@@ -16,6 +16,7 @@ hs378_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://doi.org/10.1007/978-3-642-61582-5",
   :notes => raw"""
 Schittkowski problem number 378.

--- a/src/Meta/hs38.jl
+++ b/src/Meta/hs38.jl
@@ -16,6 +16,7 @@ hs38_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS38.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 38.

--- a/src/Meta/hs39.jl
+++ b/src/Meta/hs39.jl
@@ -16,6 +16,7 @@ hs39_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS39.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 39.

--- a/src/Meta/hs4.jl
+++ b/src/Meta/hs4.jl
@@ -16,6 +16,7 @@ hs4_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS4.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 4.

--- a/src/Meta/hs40.jl
+++ b/src/Meta/hs40.jl
@@ -16,6 +16,7 @@ hs40_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS40.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 40.

--- a/src/Meta/hs41.jl
+++ b/src/Meta/hs41.jl
@@ -16,6 +16,7 @@ hs41_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS41.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 41.

--- a/src/Meta/hs42.jl
+++ b/src/Meta/hs42.jl
@@ -16,6 +16,7 @@ hs42_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS42.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 42.

--- a/src/Meta/hs43.jl
+++ b/src/Meta/hs43.jl
@@ -16,6 +16,7 @@ hs43_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS43.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 43.

--- a/src/Meta/hs44.jl
+++ b/src/Meta/hs44.jl
@@ -16,6 +16,7 @@ hs44_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS44.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 44.

--- a/src/Meta/hs45.jl
+++ b/src/Meta/hs45.jl
@@ -16,6 +16,7 @@ hs45_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS45.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 45.

--- a/src/Meta/hs46.jl
+++ b/src/Meta/hs46.jl
@@ -16,6 +16,7 @@ hs46_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS46.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 46.

--- a/src/Meta/hs47.jl
+++ b/src/Meta/hs47.jl
@@ -16,6 +16,7 @@ hs47_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS47.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 47.

--- a/src/Meta/hs48.jl
+++ b/src/Meta/hs48.jl
@@ -16,6 +16,7 @@ hs48_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS48.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 48.

--- a/src/Meta/hs49.jl
+++ b/src/Meta/hs49.jl
@@ -16,6 +16,7 @@ hs49_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS49.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 49.

--- a/src/Meta/hs5.jl
+++ b/src/Meta/hs5.jl
@@ -16,6 +16,7 @@ hs5_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS5.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 5.

--- a/src/Meta/hs50.jl
+++ b/src/Meta/hs50.jl
@@ -16,6 +16,7 @@ hs50_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS50.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 50.

--- a/src/Meta/hs51.jl
+++ b/src/Meta/hs51.jl
@@ -16,6 +16,7 @@ hs51_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS51.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 51.

--- a/src/Meta/hs52.jl
+++ b/src/Meta/hs52.jl
@@ -16,6 +16,7 @@ hs52_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS52.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 52.

--- a/src/Meta/hs53.jl
+++ b/src/Meta/hs53.jl
@@ -16,6 +16,7 @@ hs53_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS53.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 53.

--- a/src/Meta/hs54.jl
+++ b/src/Meta/hs54.jl
@@ -16,6 +16,7 @@ hs54_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS54.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 54.

--- a/src/Meta/hs55.jl
+++ b/src/Meta/hs55.jl
@@ -16,6 +16,7 @@ hs55_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS55.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 54.

--- a/src/Meta/hs56.jl
+++ b/src/Meta/hs56.jl
@@ -16,6 +16,7 @@ hs56_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS56.SIF",
   :notes => raw"""
         classification OOR2-AN-7-4

--- a/src/Meta/hs57.jl
+++ b/src/Meta/hs57.jl
@@ -16,6 +16,7 @@ hs57_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS57.SIF",
   :notes => raw"""
 classification SQR2-AN-2-1

--- a/src/Meta/hs59.jl
+++ b/src/Meta/hs59.jl
@@ -16,6 +16,7 @@ hs59_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS59.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 54.

--- a/src/Meta/hs6.jl
+++ b/src/Meta/hs6.jl
@@ -16,6 +16,7 @@ hs6_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS6.SIF",
   :notes => raw"""
 classification QQR2-AN-2-1

--- a/src/Meta/hs60.jl
+++ b/src/Meta/hs60.jl
@@ -16,6 +16,7 @@ hs60_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS60.SIF",
   :notes => raw"""
         Hock and Schittkowski problem number 60.

--- a/src/Meta/hs61.jl
+++ b/src/Meta/hs61.jl
@@ -16,6 +16,7 @@ hs61_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS61.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 61.

--- a/src/Meta/hs62.jl
+++ b/src/Meta/hs62.jl
@@ -16,6 +16,7 @@ hs62_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS62.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 62.

--- a/src/Meta/hs63.jl
+++ b/src/Meta/hs63.jl
@@ -16,6 +16,7 @@ hs63_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS63.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 63.

--- a/src/Meta/hs64.jl
+++ b/src/Meta/hs64.jl
@@ -16,6 +16,7 @@ hs64_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS64.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 64.

--- a/src/Meta/hs65.jl
+++ b/src/Meta/hs65.jl
@@ -16,6 +16,7 @@ hs65_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS65.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 65.

--- a/src/Meta/hs66.jl
+++ b/src/Meta/hs66.jl
@@ -16,6 +16,7 @@ hs66_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS66.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 66.

--- a/src/Meta/hs68.jl
+++ b/src/Meta/hs68.jl
@@ -16,6 +16,7 @@ hs68_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS68.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 68.

--- a/src/Meta/hs69.jl
+++ b/src/Meta/hs69.jl
@@ -16,6 +16,7 @@ hs69_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS69.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 69.

--- a/src/Meta/hs7.jl
+++ b/src/Meta/hs7.jl
@@ -16,6 +16,7 @@ hs7_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS7.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 7.

--- a/src/Meta/hs70.jl
+++ b/src/Meta/hs70.jl
@@ -16,6 +16,7 @@ hs70_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS70.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 70.

--- a/src/Meta/hs71.jl
+++ b/src/Meta/hs71.jl
@@ -16,6 +16,7 @@ hs71_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS71.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 71.

--- a/src/Meta/hs72.jl
+++ b/src/Meta/hs72.jl
@@ -16,6 +16,7 @@ hs72_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS72.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 72.

--- a/src/Meta/hs73.jl
+++ b/src/Meta/hs73.jl
@@ -16,6 +16,7 @@ hs73_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS73.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 73.

--- a/src/Meta/hs74.jl
+++ b/src/Meta/hs74.jl
@@ -16,6 +16,7 @@ hs74_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS74.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 74.

--- a/src/Meta/hs75.jl
+++ b/src/Meta/hs75.jl
@@ -16,6 +16,7 @@ hs75_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS75.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 75.

--- a/src/Meta/hs76.jl
+++ b/src/Meta/hs76.jl
@@ -16,6 +16,7 @@ hs76_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS76.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 76.

--- a/src/Meta/hs77.jl
+++ b/src/Meta/hs77.jl
@@ -16,6 +16,7 @@ hs77_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS77.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 77.

--- a/src/Meta/hs78.jl
+++ b/src/Meta/hs78.jl
@@ -16,6 +16,7 @@ hs78_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS78.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 78.

--- a/src/Meta/hs79.jl
+++ b/src/Meta/hs79.jl
@@ -16,6 +16,7 @@ hs79_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS79.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 79.

--- a/src/Meta/hs8.jl
+++ b/src/Meta/hs8.jl
@@ -16,6 +16,7 @@ hs8_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS8.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 8.

--- a/src/Meta/hs80.jl
+++ b/src/Meta/hs80.jl
@@ -16,6 +16,7 @@ hs80_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS80.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 80.

--- a/src/Meta/hs81.jl
+++ b/src/Meta/hs81.jl
@@ -16,6 +16,7 @@ hs81_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS81.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 81.

--- a/src/Meta/hs83.jl
+++ b/src/Meta/hs83.jl
@@ -16,6 +16,7 @@ hs83_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS83.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 83.

--- a/src/Meta/hs84.jl
+++ b/src/Meta/hs84.jl
@@ -16,6 +16,7 @@ hs84_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS84.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 84.

--- a/src/Meta/hs86.jl
+++ b/src/Meta/hs86.jl
@@ -16,6 +16,7 @@ hs86_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS86.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 86.

--- a/src/Meta/hs87.jl
+++ b/src/Meta/hs87.jl
@@ -16,6 +16,7 @@ hs87_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS87.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 87.

--- a/src/Meta/hs9.jl
+++ b/src/Meta/hs9.jl
@@ -16,6 +16,7 @@ hs9_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS9.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 9.

--- a/src/Meta/hs93.jl
+++ b/src/Meta/hs93.jl
@@ -16,6 +16,7 @@ hs93_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS93.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 93.

--- a/src/Meta/hs95.jl
+++ b/src/Meta/hs95.jl
@@ -16,6 +16,7 @@ hs95_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS95.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 95.

--- a/src/Meta/hs96.jl
+++ b/src/Meta/hs96.jl
@@ -16,6 +16,7 @@ hs96_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS96.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 96.

--- a/src/Meta/hs97.jl
+++ b/src/Meta/hs97.jl
@@ -16,6 +16,7 @@ hs97_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS97.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 97.

--- a/src/Meta/hs98.jl
+++ b/src/Meta/hs98.jl
@@ -16,6 +16,7 @@ hs98_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS98.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 98.

--- a/src/Meta/hs99.jl
+++ b/src/Meta/hs99.jl
@@ -16,6 +16,7 @@ hs99_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/HS99.SIF",
   :notes => raw"""
 Hock and Schittkowski problem number 99.

--- a/src/Meta/indef_mod.jl
+++ b/src/Meta/indef_mod.jl
@@ -16,6 +16,7 @@ indef_mod_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "http://www.cs.cas.cz/matonoha/download/V1081.pdf",
   :notes => raw"""
 Problem 37 in

--- a/src/Meta/integreq.jl
+++ b/src/Meta/integreq.jl
@@ -16,6 +16,7 @@ integreq_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/INTEGREQ.SIF",
   :notes => raw"""
 The discrete integral problem.

--- a/src/Meta/jennrichsampson.jl
+++ b/src/Meta/jennrichsampson.jl
@@ -16,6 +16,7 @@ jennrichsampson_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1145/355934.355936",
   :notes => raw"""
 

--- a/src/Meta/kirby2.jl
+++ b/src/Meta/kirby2.jl
@@ -16,6 +16,7 @@ kirby2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/KIRBY2.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/kirby2.dat

--- a/src/Meta/kowosb.jl
+++ b/src/Meta/kowosb.jl
@@ -16,6 +16,7 @@ kowosb_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/KOWOSB.SIF",
   :notes => raw"""
 A problem arising in the analysis of kinetic data for an enzyme

--- a/src/Meta/lanczos1.jl
+++ b/src/Meta/lanczos1.jl
@@ -16,6 +16,7 @@ lanczos1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/LANCZOS1.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/lanczos1.dat

--- a/src/Meta/lanczos2.jl
+++ b/src/Meta/lanczos2.jl
@@ -16,6 +16,7 @@ lanczos2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/LANCZOS2.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/lanczos2.dat

--- a/src/Meta/lanczos3.jl
+++ b/src/Meta/lanczos3.jl
@@ -16,6 +16,7 @@ lanczos3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/LANCZOS3.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/lanczos3.dat

--- a/src/Meta/liarwhd.jl
+++ b/src/Meta/liarwhd.jl
@@ -16,6 +16,7 @@ liarwhd_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/LIARWHD.SIF",
   :notes => raw"""
 G. Li,

--- a/src/Meta/lincon.jl
+++ b/src/Meta/lincon.jl
@@ -16,6 +16,7 @@ lincon_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl",
   :notes => raw"""
 

--- a/src/Meta/linsv.jl
+++ b/src/Meta/linsv.jl
@@ -16,6 +16,7 @@ linsv_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl",
   :notes => raw"""
 

--- a/src/Meta/marine.jl
+++ b/src/Meta/marine.jl
@@ -16,6 +16,7 @@ marine_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MARINE.SIF",
   :notes => raw"""
 Marine Population Dynamics Problem

--- a/src/Meta/methanol.jl
+++ b/src/Meta/methanol.jl
@@ -16,6 +16,7 @@ methanol_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://bitbucket.org/optrove/sif/src/master/METHANOL.SIF",
   :notes => raw"""
 Methanol-to-Hydrocarbons Problem

--- a/src/Meta/meyer3.jl
+++ b/src/Meta/meyer3.jl
@@ -16,6 +16,7 @@ meyer3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MEYER3.SIF",
   :notes => raw"""
 Meyer function

--- a/src/Meta/mgh01feas.jl
+++ b/src/Meta/mgh01feas.jl
@@ -16,6 +16,7 @@ mgh01feas_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl",
   :notes => raw"""
 

--- a/src/Meta/mgh09.jl
+++ b/src/Meta/mgh09.jl
@@ -16,6 +16,7 @@ mgh09_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MGH09.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/mgh09.dat

--- a/src/Meta/mgh10.jl
+++ b/src/Meta/mgh10.jl
@@ -16,6 +16,7 @@ mgh10_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => false,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MGH10.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/mgh10.dat

--- a/src/Meta/mgh17.jl
+++ b/src/Meta/mgh17.jl
@@ -16,6 +16,7 @@ mgh17_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MGH17.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/mgh17.dat

--- a/src/Meta/minsurf.jl
+++ b/src/Meta/minsurf.jl
@@ -16,6 +16,7 @@ minsurf_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://bitbucket.org/optrove/sif/src/master/MINSURF.SIF",
   :notes => raw"""
 Minimal surface with obstacle problem

--- a/src/Meta/misra1a.jl
+++ b/src/Meta/misra1a.jl
@@ -16,6 +16,7 @@ misra1a_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MISRA1A.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/misra1a.dat

--- a/src/Meta/misra1b.jl
+++ b/src/Meta/misra1b.jl
@@ -16,6 +16,7 @@ misra1b_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MISRA1B.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/misra1b.dat

--- a/src/Meta/misra1c.jl
+++ b/src/Meta/misra1c.jl
@@ -16,6 +16,7 @@ misra1c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MISRA1C.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/misra1c.dat

--- a/src/Meta/misra1d.jl
+++ b/src/Meta/misra1d.jl
@@ -16,6 +16,7 @@ misra1d_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MISRA1D.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/misra1d.dat

--- a/src/Meta/morebv.jl
+++ b/src/Meta/morebv.jl
@@ -16,6 +16,7 @@ morebv_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/MOREBV.SIF",
   :notes => raw"""
 The Boundary Value problem.

--- a/src/Meta/nasty.jl
+++ b/src/Meta/nasty.jl
@@ -16,6 +16,7 @@ nasty_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "",
   :notes => raw"""
 Nasty problem.

--- a/src/Meta/nazareth.jl
+++ b/src/Meta/nazareth.jl
@@ -16,6 +16,7 @@ nazareth_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Sparse modification of the Nazareth trigonometric function

--- a/src/Meta/ncb20.jl
+++ b/src/Meta/ncb20.jl
@@ -16,6 +16,7 @@ ncb20_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/NCB20.SIF",
   :notes => raw"""
 A banded problem with semi-bandwidth 20.  This problem exhibits frequent

--- a/src/Meta/ncb20b.jl
+++ b/src/Meta/ncb20b.jl
@@ -16,6 +16,7 @@ ncb20b_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/NCB20B.SIF",
   :notes => raw"""
 A banded problem with semi-bandwidth 20.  This problem exhibits frequent

--- a/src/Meta/nelson.jl
+++ b/src/Meta/nelson.jl
@@ -16,6 +16,7 @@ nelson_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => false,
   :origin => :real,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/NELSON.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/nelson.dat

--- a/src/Meta/noncvxu2.jl
+++ b/src/Meta/noncvxu2.jl
@@ -16,6 +16,7 @@ noncvxu2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/NONCVXU2.SIF",
   :notes => raw"""
 A nonconvex unconstrained function with a unique minimum value

--- a/src/Meta/noncvxun.jl
+++ b/src/Meta/noncvxun.jl
@@ -16,6 +16,7 @@ noncvxun_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/NONCVXUN.SIF",
   :notes => raw"""
 A nonconvex unconstrained function with a unique minimum value

--- a/src/Meta/nondia.jl
+++ b/src/Meta/nondia.jl
@@ -16,6 +16,7 @@ nondia_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/NONDIA.SIF",
   :notes => raw"""
 The Shanno nondiagonal extension of Rosenbrock function.

--- a/src/Meta/nondquar.jl
+++ b/src/Meta/nondquar.jl
@@ -16,6 +16,7 @@ nondquar_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/NONDQUAR.SIF",
   :notes => raw"""
 A nondiagonal quartic test problem.

--- a/src/Meta/osborne1.jl
+++ b/src/Meta/osborne1.jl
@@ -16,6 +16,7 @@ osborne1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/OSBORNE1.SIF",
   :notes => raw"""
 Osborne first problem in 5 variables. This is a nonlinear equation version

--- a/src/Meta/osborne2.jl
+++ b/src/Meta/osborne2.jl
@@ -16,6 +16,7 @@ osborne2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/OSBORNE2.SIF",
   :notes => raw"""
 Osborne second problem in 11 variables. This is a nonlinear equation version

--- a/src/Meta/palmer1c.jl
+++ b/src/Meta/palmer1c.jl
@@ -16,6 +16,7 @@ palmer1c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER1C.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer1d.jl
+++ b/src/Meta/palmer1d.jl
@@ -16,6 +16,7 @@ palmer1d_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER1D.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer2c.jl
+++ b/src/Meta/palmer2c.jl
@@ -16,6 +16,7 @@ palmer2c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER2C.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer3c.jl
+++ b/src/Meta/palmer3c.jl
@@ -16,6 +16,7 @@ palmer3c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER3C.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer4c.jl
+++ b/src/Meta/palmer4c.jl
@@ -16,6 +16,7 @@ palmer4c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER4C.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer5c.jl
+++ b/src/Meta/palmer5c.jl
@@ -16,6 +16,7 @@ palmer5c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER5C.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer5d.jl
+++ b/src/Meta/palmer5d.jl
@@ -16,6 +16,7 @@ palmer5d_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER5D.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer6c.jl
+++ b/src/Meta/palmer6c.jl
@@ -16,6 +16,7 @@ palmer6c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER6C.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer7c.jl
+++ b/src/Meta/palmer7c.jl
@@ -16,6 +16,7 @@ palmer7c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER7C.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/palmer8c.jl
+++ b/src/Meta/palmer8c.jl
@@ -16,6 +16,7 @@ palmer8c_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PALMER8C.SIF",
   :notes => raw"""
 A linear least squares problem arising from chemical kinetics.

--- a/src/Meta/penalty1.jl
+++ b/src/Meta/penalty1.jl
@@ -16,6 +16,7 @@ penalty1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PENALTY1.SIF",
   :notes => raw"""
 A penalty function arising from

--- a/src/Meta/penalty2.jl
+++ b/src/Meta/penalty2.jl
@@ -16,6 +16,7 @@ penalty2_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PENALTY2.SIF",
   :notes => raw"""
 The second penalty function

--- a/src/Meta/penalty3.jl
+++ b/src/Meta/penalty3.jl
@@ -16,6 +16,7 @@ penalty3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/PENALTY3.SIF",
   :notes => raw"""
 A penalty problem by Gill, Murray and Pitfield.

--- a/src/Meta/pinene.jl
+++ b/src/Meta/pinene.jl
@@ -16,6 +16,7 @@ pinene_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://bitbucket.org/optrove/sif/src/master/PINENE.SIF",
   :notes => raw"""
 Isomerization of Alpha-Pinene Problem

--- a/src/Meta/polygon.jl
+++ b/src/Meta/polygon.jl
@@ -16,6 +16,7 @@ polygon_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/POLYGON.SIF",
   :notes => raw"""
 Find the polygon of maximal area, among polygons with nv sides and diameter d <= 1

--- a/src/Meta/polygon1.jl
+++ b/src/Meta/polygon1.jl
@@ -16,6 +16,7 @@ polygon1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Find the polygon of maximal area, among polygons with nv sides and diameter d <= 1

--- a/src/Meta/polygon2.jl
+++ b/src/Meta/polygon2.jl
@@ -16,6 +16,7 @@ polygon2_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://laurentlessard.com/teaching/524-intro-to-optimization/",
   :notes => raw"""
 Find the polygon of maximal area, among polygons with nv sides and diameter d <= 1

--- a/src/Meta/polygon3.jl
+++ b/src/Meta/polygon3.jl
@@ -16,6 +16,7 @@ polygon3_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://laurentlessard.com/teaching/524-intro-to-optimization/",
   :notes => raw"""
 Find the polygon of maximal area, among polygons with nv sides and diameter d <= 1

--- a/src/Meta/powellbs.jl
+++ b/src/Meta/powellbs.jl
@@ -16,6 +16,7 @@ powellbs_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/POWELLBS.SIF",
   :notes => raw"""
 Powell badly scaled problem.

--- a/src/Meta/powellsg.jl
+++ b/src/Meta/powellsg.jl
@@ -16,6 +16,7 @@ powellsg_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/POWELLSG.SIF",
   :notes => raw"""
 The extended Powell singular problem.

--- a/src/Meta/power.jl
+++ b/src/Meta/power.jl
@@ -16,6 +16,7 @@ power_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/POWER.SIF",
   :notes => raw"""
 The Power problem by Oren.

--- a/src/Meta/quartc.jl
+++ b/src/Meta/quartc.jl
@@ -16,6 +16,7 @@ quartc_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/QUARTC.SIF",
   :notes => raw"""
 A simple quartic function.

--- a/src/Meta/rat42.jl
+++ b/src/Meta/rat42.jl
@@ -16,6 +16,7 @@ rat42_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/RAT42.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/rat42.dat

--- a/src/Meta/rat43.jl
+++ b/src/Meta/rat43.jl
@@ -16,6 +16,7 @@ rat43_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/RAT43.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/rat43.dat

--- a/src/Meta/robotarm.jl
+++ b/src/Meta/robotarm.jl
@@ -16,6 +16,7 @@ robotarm_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ROBOTARM.SIF",
   :notes => raw"""
 Minimize the time taken for a robot arm to travel between two points.

--- a/src/Meta/rocket.jl
+++ b/src/Meta/rocket.jl
@@ -16,6 +16,7 @@ rocket_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://bitbucket.org/optrove/sif/src/master/ROCKET.SIF",
   :notes => raw"""
 Goddard Rocket Problem

--- a/src/Meta/rosenbrock.jl
+++ b/src/Meta/rosenbrock.jl
@@ -16,6 +16,7 @@ rosenbrock_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.1093/comjnl/3.3.175",
   :notes => raw"""
 The classical 2-variable Rosenbrock (banana valley) function, a special case of the

--- a/src/Meta/rozman1.jl
+++ b/src/Meta/rozman1.jl
@@ -16,6 +16,7 @@ rozman1_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/rozman1.dat",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/rozman1.dat

--- a/src/Meta/sbrybnd.jl
+++ b/src/Meta/sbrybnd.jl
@@ -16,6 +16,7 @@ sbrybnd_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/SBRYBND.SIF",
   :notes => raw"""
 Broyden banded system of nonlinear equations, considered in the

--- a/src/Meta/schmvett.jl
+++ b/src/Meta/schmvett.jl
@@ -16,6 +16,7 @@ schmvett_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/SCHMVETT.SIF",
   :notes => raw"""
 The Schmidt and Vetters problem.

--- a/src/Meta/scosine.jl
+++ b/src/Meta/scosine.jl
@@ -16,6 +16,7 @@ scosine_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/SCOSINE.SIF",
   :notes => raw"""
 Another function with nontrivial groups and

--- a/src/Meta/sinquad.jl
+++ b/src/Meta/sinquad.jl
@@ -16,6 +16,7 @@ sinquad_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/SINQUAD.SIF",
   :notes => raw"""
 Another function with nontrivial groups and

--- a/src/Meta/sparsine.jl
+++ b/src/Meta/sparsine.jl
@@ -16,6 +16,7 @@ sparsine_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/SPARSINE.SIF",
   :notes => raw"""
 A sparse problem involving sine functions

--- a/src/Meta/sparsqur.jl
+++ b/src/Meta/sparsqur.jl
@@ -16,6 +16,7 @@ sparsqur_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/SPARSQUR.SIF",
   :notes => raw"""
 A sparse quartic problem

--- a/src/Meta/spmsrtls.jl
+++ b/src/Meta/spmsrtls.jl
@@ -16,6 +16,7 @@ spmsrtls_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/SPMSRTLS.SIF",
   :notes => raw"""
 Liu and Nocedal tridiagonal matrix square root problem.

--- a/src/Meta/srosenbr.jl
+++ b/src/Meta/srosenbr.jl
@@ -16,6 +16,7 @@ srosenbr_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/SROSENBR.SIF",
   :notes => raw"""
 The separable extension of Rosenbrock's function.

--- a/src/Meta/steering.jl
+++ b/src/Meta/steering.jl
@@ -16,6 +16,7 @@ steering_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://bitbucket.org/optrove/sif/src/master/STEERING.SIF",
   :notes => raw"""
 Rocket Steering Problem

--- a/src/Meta/structural.jl
+++ b/src/Meta/structural.jl
@@ -25,6 +25,7 @@ structural_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://laurentlessard.com/teaching/524-intro-to-optimization/",
   :notes => raw"""
 JuMP model follows Laurent Lessard CS/ECE/ISyE 524, University of Wisconsin–Madison, 

--- a/src/Meta/tetra.jl
+++ b/src/Meta/tetra.jl
@@ -16,6 +16,7 @@ tetra_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/tetra_duct12.jl
+++ b/src/Meta/tetra_duct12.jl
@@ -16,6 +16,7 @@ tetra_duct12_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/tetra_duct15.jl
+++ b/src/Meta/tetra_duct15.jl
@@ -16,6 +16,7 @@ tetra_duct15_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/tetra_duct20.jl
+++ b/src/Meta/tetra_duct20.jl
@@ -16,6 +16,7 @@ tetra_duct20_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/tetra_foam5.jl
+++ b/src/Meta/tetra_foam5.jl
@@ -16,6 +16,7 @@ tetra_foam5_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/tetra_gear.jl
+++ b/src/Meta/tetra_gear.jl
@@ -16,6 +16,7 @@ tetra_gear_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/tetra_hook.jl
+++ b/src/Meta/tetra_hook.jl
@@ -16,6 +16,7 @@ tetra_hook_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/threepk.jl
+++ b/src/Meta/threepk.jl
@@ -16,6 +16,7 @@ threepk_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/3PK.SIF",
   :notes => raw"""
 A problem arising in the estimation of structured O/D matrix

--- a/src/Meta/thurber.jl
+++ b/src/Meta/thurber.jl
@@ -16,6 +16,7 @@ thurber_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/THURBER.SIF",
   :notes => raw"""
 https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/thurber.dat

--- a/src/Meta/toint.jl
+++ b/src/Meta/toint.jl
@@ -16,6 +16,7 @@ toint_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Toint trigonometric function

--- a/src/Meta/tointgss.jl
+++ b/src/Meta/tointgss.jl
@@ -16,6 +16,7 @@ tointgss_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/TOINTGSS.SIF",
   :notes => raw"""
 Toint's Gaussian problem.

--- a/src/Meta/torsion.jl
+++ b/src/Meta/torsion.jl
@@ -16,6 +16,7 @@ torsion_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :jump,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Torsion problem

--- a/src/Meta/tquartic.jl
+++ b/src/Meta/tquartic.jl
@@ -16,6 +16,7 @@ tquartic_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/TQUARTIC.SIF",
   :notes => raw"""
 A quartic function with nontrivial groups and

--- a/src/Meta/triangle.jl
+++ b/src/Meta/triangle.jl
@@ -16,6 +16,7 @@ triangle_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the time taken for a robot arm to travel between two points.

--- a/src/Meta/triangle_deer.jl
+++ b/src/Meta/triangle_deer.jl
@@ -16,6 +16,7 @@ triangle_deer_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/triangle_pacman.jl
+++ b/src/Meta/triangle_pacman.jl
@@ -16,6 +16,7 @@ triangle_pacman_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/triangle_turtle.jl
+++ b/src/Meta/triangle_turtle.jl
@@ -16,6 +16,7 @@ triangle_turtle_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://doi.org/10.2172/834714",
   :notes => raw"""
 Minimize the sum of the inverse weighted mean ratio of the elements in a fixed–boundary

--- a/src/Meta/tridia.jl
+++ b/src/Meta/tridia.jl
@@ -16,6 +16,7 @@ tridia_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/TRIDIA.SIF",
   :notes => raw"""
 Shanno's TRIDIA quadratic tridiagonal problem.

--- a/src/Meta/trig.jl
+++ b/src/Meta/trig.jl
@@ -16,6 +16,7 @@ trig_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Another trigonometric function

--- a/src/Meta/trigb.jl
+++ b/src/Meta/trigb.jl
@@ -16,6 +16,7 @@ trigb_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Banded trigonometric problem

--- a/src/Meta/vardim.jl
+++ b/src/Meta/vardim.jl
@@ -16,6 +16,7 @@ vardim_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/VARDIM.SIF",
   :notes => raw"""
 Variable dimension problem.

--- a/src/Meta/variational.jl
+++ b/src/Meta/variational.jl
@@ -16,6 +16,7 @@ variational_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => false,
   :origin => :academic,
+  :implementation => :both,
   :url => "https://www.researchgate.net/publication/325314400_Sparse_Test_Problems_for_Unconstrained_Optimization",
   :notes => raw"""
 Discretization of a variational problem

--- a/src/Meta/vibrbeam.jl
+++ b/src/Meta/vibrbeam.jl
@@ -16,6 +16,7 @@ vibrbeam_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/VIBRBEAM.SIF",
   :notes => raw"""
 A nonlinear least-squares problem arising from laser-Doppler

--- a/src/Meta/watson.jl
+++ b/src/Meta/watson.jl
@@ -16,6 +16,7 @@ watson_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/WATSON.SIF",
   :notes => raw"""
 Watson problem in variable dimension ( 2 <= n <= 31 ).

--- a/src/Meta/woods.jl
+++ b/src/Meta/woods.jl
@@ -16,6 +16,7 @@ woods_meta = Dict(
   :is_feasible => true,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/WOODS.SIF",
   :notes => raw"""
 The extended Woods problem.

--- a/src/Meta/zangwil3.jl
+++ b/src/Meta/zangwil3.jl
@@ -16,6 +16,7 @@ zangwil3_meta = Dict(
   :is_feasible => missing,
   :defined_everywhere => missing,
   :origin => :unknown,
+  :implementation => :both,
   :url => "https://bitbucket.org/optrove/sif/src/master/ZANGWIL3.SIF",
   :notes => raw"""
 Zangwill's problem in 3 variables.

--- a/src/OptimizationProblems.jl
+++ b/src/OptimizationProblems.jl
@@ -49,6 +49,7 @@ const cols_names = [
   :is_feasible
   :defined_everywhere
   :origin
+  :implementation
   :url
   :notes
   :origin_notes
@@ -73,6 +74,7 @@ const types = [
   Real
   Union{Bool, Missing}
   Union{Bool, Missing}
+  Symbol
   Symbol
   String
   String
@@ -106,6 +108,7 @@ The following keys are valid:
   - `is_feasible::Union{Bool, Missing}`: true if problem is feasible
   - `defined_everywhere::Union{Bool, Missing}`: true if the objective is define for all values of the variables
   - `origin::Symbol`: origin of the problem, in [:academic, :modelling, :real, :unknown]
+  - `implementation::Symbol`: takes the value :jump, :adnlpmodels or :both whether the problem is defined in PureJuMP, ADNLPProblems, or both
   - `url::String`: URL where the problem can be found
   - `notes::String`: any additional notes about the problem
   - `origin_notes::String`: any additional notes about the origin of the problem

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,14 +21,14 @@ end
   @test sort(list_problems) == sort(Symbol.(OptimizationProblems.meta[!, :name]))
 end
 
-# The problems included should be carefully argumented and issues
-# to create them added.
-# TODO: tests are limited for JuMP-only problems
-@everywhere const list_problems_not_ADNLPProblems =
-  Symbol[:catmix, :gasoil, :glider, :methanol, :minsurf, :pinene, :rocket, :steering, :torsion]
+@everywhere const list_problems_not_ADNLPProblems = Symbol.(
+  OptimizationProblems.meta[OptimizationProblems.meta.implementation .== :jump, :name]
+)
 @everywhere const list_problems_ADNLPProblems =
   setdiff(list_problems, list_problems_not_ADNLPProblems)
-@everywhere const list_problems_not_PureJuMP = Symbol[]
+@everywhere const list_problems_not_PureJuMP = Symbol.(
+  OptimizationProblems.meta[OptimizationProblems.meta.implementation .== :adnlpmodels, :name]
+)
 @everywhere const list_problems_PureJuMP = setdiff(list_problems, list_problems_not_PureJuMP)
 
 include("test-defined-problems.jl")

--- a/test/test-meta-fields.jl
+++ b/test/test-meta-fields.jl
@@ -57,6 +57,33 @@ end
   @test isempty(invalid)
 end
 
+@testset "Meta fields: :implementation values and consistency" begin
+  valid_impl = (:both, :jump, :adnlpmodels)
+
+  invalid_value = [
+    row[:name] for row in eachrow(OptimizationProblems.meta)
+    if row[:implementation] ∉ valid_impl
+  ]
+  for name in invalid_value
+    @error "Problem $name has invalid :implementation value: $(OptimizationProblems.meta[OptimizationProblems.meta.name .== name, :implementation][1])"
+  end
+  @test isempty(invalid_value)
+
+  for row in eachrow(OptimizationProblems.meta)
+    prob = Symbol(row[:name])
+    impl = row[:implementation]
+    in_adnlp = isdefined(ADNLPProblems, prob)
+    in_jump = isdefined(PureJuMP, prob)
+    if impl == :both
+      @test in_adnlp && in_jump
+    elseif impl == :jump
+      @test !in_adnlp && in_jump
+    elseif impl == :adnlpmodels
+      @test in_adnlp && !in_jump
+    end
+  end
+end
+
 @testset "Meta fields: :lib format" begin
   invalid = Tuple{String, String, String}[]
   for row in eachrow(OptimizationProblems.meta)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -106,13 +106,14 @@ function generate_meta(
   :is_feasible => $(feasible),
   :defined_everywhere => $(missing),
   :origin => :$(origin),
+  :implementation => :both,
 )
-get_$(name)_nvar(; n::Integer = default_nvar, kwargs...) = $nvar_formula
-get_$(name)_ncon(; n::Integer = default_nvar, kwargs...) = $ncon_formula
-get_$(name)_nlin(; n::Integer = default_nvar, kwargs...) = $nlin_formula
-get_$(name)_nnln(; n::Integer = default_nvar, kwargs...) = $nnln_formula
-get_$(name)_nequ(; n::Integer = default_nvar, kwargs...) = $nequ_formula
-get_$(name)_nineq(; n::Integer = default_nvar, kwargs...) = $nineq_formula
+get_$(name)_nvar(; n::Int = default_nvar, kwargs...) = $nvar_formula
+get_$(name)_ncon(; n::Int = default_nvar, kwargs...) = $ncon_formula
+get_$(name)_nlin(; n::Int = default_nvar, kwargs...) = $nlin_formula
+get_$(name)_nnln(; n::Int = default_nvar, kwargs...) = $nnln_formula
+get_$(name)_nequ(; n::Int = default_nvar, kwargs...) = $nequ_formula
+get_$(name)_nineq(; n::Int = default_nvar, kwargs...) = $nineq_formula
 "
   return str
 end


### PR DESCRIPTION
Add a new field `implementation` (see https://github.com/JuliaSmoothOptimizers/OptimizationProblems.jl/issues/415) that  take `jump` if the problem is defined in PureJuMP, `adnlpmodels` if the problem is defined in ADNLPProblems, or `both` if both. 