### PR TITLE
Fix documentation issues (W-DOC-2, W-DOC-5, I-DOC-1, I-DOC-4)

### DIFF
--- a/docs/src/benchmark.md
+++ b/docs/src/benchmark.md
@@ -12,13 +12,13 @@ using OptimizationProblems.PureJuMP
 ```
 We select the problems from `PureJuMP` submodule of `OptimizationProblems` converted in [NLPModels](https://github.com/JuliaSmoothOptimizers/NLPModels.jl) using [NLPModelsJuMP](https://github.com/JuliaSmoothOptimizers/NLPModelsJuMP.jl).
 ``` @example ex1
-problems = (MathOptNLPModel(OptimizationProblems.PureJuMP.eval(Meta.parse(problem))(), name=problem) for problem ∈ OptimizationProblems.meta[!, :name])
+problems = (MathOptNLPModel(getproperty(OptimizationProblems.PureJuMP, Symbol(problem))(), name=problem) for problem ∈ OptimizationProblems.meta[!, :name])
 ```
 The same can be achieved using `OptimizationProblems.ADNLPProblems` instead of `OptimizationProblems.PureJuMP` as follows:
 ``` @example ex1
 using ADNLPModels
 using OptimizationProblems.ADNLPProblems
-ad_problems = (OptimizationProblems.ADNLPProblems.eval(Meta.parse(problem))() for problem ∈ OptimizationProblems.meta[!, :name])
+ad_problems = (getproperty(OptimizationProblems.ADNLPProblems, Symbol(problem))() for problem ∈ OptimizationProblems.meta[!, :name])
 ```
 
 We also define a dictionary of solvers that will be used for our benchmark. We consider here `JSOSolvers.lbfgs` and `JSOSolvers.trunk`.
@@ -74,5 +74,5 @@ It is also possible to select problems when initializing the problem list by fil
 ```
 meta = OptimizationProblems.meta
 problem_list = meta[(meta.ncon .== 0) .& .!meta.has_bounds .& (5 .<= meta.nvar .<= 100), :name]
-problems = (MathOptNLPModel(eval(Meta.parse(problem))(), name=problem) for problem ∈ problem_list)
+problems = (MathOptNLPModel(getproperty(OptimizationProblems.PureJuMP, Symbol(problem))(), name=problem) for problem ∈ problem_list)
 ```

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -46,7 +46,7 @@ First, we describe the `PureJuMP` file `function_name.jl`. Problem documentation
 ```
 export function_name
 
-function function_name(; n::Int = default_nvar, kwargs...)
+function function_name(args...; n::Int = default_nvar, kwargs...)
   nlp = Model()
   # define the model: TODO
   return nlp
@@ -137,6 +137,6 @@ See existing NLS problems (e.g., [`lanczos1`](https://github.com/JuliaSmoothOpti
 - [ ] Objective evaluation has minimal allocations (ideally allocation-free in performance-critical paths).
 
 **Least-Squares & In-Place APIs**
-- [ ] If least squares, ADNLP constructor supports `nls=true/false` for both ADNLPModel and ADNLSModel.
+- [ ] If least squares, ADNLP constructor supports `use_nls=true/false` for both ADNLPModel and ADNLSModel.
 - [ ] In-place nonlinear constraint evaluations (`cons_nln!(nlp, x, cx)`) and least squares residuals (`residual!`) are allocation-free.
 - [ ] For least squares problems, objectives for NLP and NLS must agree (or differ by a factor of 2, as appropriate).

--- a/docs/src/meta.md
+++ b/docs/src/meta.md
@@ -100,7 +100,7 @@ cutest_problems = meta[contains.(meta.lib, "CUTEst"), [:name, :lib]]
 each collection, and [`export_bibtex`](@ref) automatically appends them when
 `include_lib_refs = true` (the default).
 
-## Problem'source information
+## Problem source information
 
 The following code will create a .bib file regrouping all the BibTex citations.
 ```julia


### PR DESCRIPTION
## Summary

Four documentation issues from the repository audit, fixed across `benchmark.md`, `contributing.md`, and `meta.md`.

- **W-DOC-2** (`benchmark.md`): Replace all three `eval(Meta.parse(problem))()` calls with `getproperty(..., Symbol(problem))()`. The `eval(Meta.parse(...))` idiom is slower, harder to read, and was superseded in Julia 1.0. This pattern is shown as tutorial code, so it teaches contributors a bad habit.
- **W-DOC-5** (`contributing.md`): Fix the reviewer checklist entry that said `nls=true/false` — the actual keyword is `use_nls=true/false`.
- **I-DOC-1** (`meta.md`): Fix typo `Problem'source information` → `Problem source information`.
- **I-DOC-4** (`contributing.md`): Add `args...` to the PureJuMP function template. Without it, contributors writing mesh or data problems (which accept positional array arguments) would follow a template that breaks at runtime.

**Note on I-DOC-3** (Cirrus CI badge): After checking, `.cirrus.yml` is present and actively configured for FreeBSD testing — the badge is legitimate and requires no change.

## Test plan

- [ ] Docs build cleanly (`julia --project=docs docs/make.jl`)
- [ ] All three `getproperty` calls in `benchmark.md` are syntactically valid
- [ ] `use_nls` keyword matches the actual ADNLPProblems implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)