### PR TITLE
Fix generate_meta to emit all 22 meta fields and add unit tests (W-SRC-3, W-DOC-4)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,5 +112,6 @@ pmap(test_one_problem, list_problems)
 
 include("test-scalable.jl")
 include("test-meta-fields.jl")
+include("test-generate-meta.jl")
 
 rmprocs()

--- a/test/test-generate-meta.jl
+++ b/test/test-generate-meta.jl
@@ -1,0 +1,60 @@
+using Distributed, NLPModels, NLPModelsJuMP, OptimizationProblems, Test
+import ADNLPModels
+
+include(joinpath(@__DIR__, "utils.jl"))
+
+# All 22 keys that every meta Dict must contain.
+const _ALL_META_KEYS = [
+  ":nvar",
+  ":variable_nvar",
+  ":ncon",
+  ":variable_ncon",
+  ":minimize",
+  ":name",
+  ":has_equalities_only",
+  ":has_inequalities_only",
+  ":has_bounds",
+  ":has_fixed_variables",
+  ":objtype",
+  ":contype",
+  ":best_known_lower_bound",
+  ":best_known_upper_bound",
+  ":is_feasible",
+  ":defined_everywhere",
+  ":origin",
+  ":url",
+  ":notes",
+  ":origin_notes",
+  ":reference",
+  ":lib",
+]
+
+@testset "generate_meta: all 22 meta keys are emitted" begin
+  nlp = OptimizationProblems.ADNLPProblems.arwhead()
+  str = generate_meta(nlp, "arwhead")
+  for key in _ALL_META_KEYS
+    @test occursin(key, str)
+  end
+end
+
+@testset "generate_meta: six getter functions are emitted" begin
+  nlp = OptimizationProblems.ADNLPProblems.arwhead()
+  str = generate_meta(nlp, "arwhead")
+  for suffix in ("nvar", "ncon", "nlin", "nnln", "nequ", "nineq")
+    @test occursin("get_arwhead_$suffix", str)
+  end
+end
+
+@testset "generate_meta: output is parseable Julia" begin
+  nlp = OptimizationProblems.ADNLPProblems.arwhead()
+  str = generate_meta(nlp, "arwhead")
+  @test Meta.parse("begin\n$str\nend") isa Expr
+end
+
+@testset "generate_meta: constrained problem emits all 22 keys" begin
+  nlp = OptimizationProblems.ADNLPProblems.hs7()
+  str = generate_meta(nlp, "hs7")
+  for key in _ALL_META_KEYS
+    @test occursin(key, str)
+  end
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,7 @@
 using ADNLPModels, Distributed, NLPModels, NLPModelsJuMP, OptimizationProblems, Test
 
 path = dirname(@__FILE__)
-include(joinpath(path, "test-utils.jl"))
+@isdefined(ndef) || include(joinpath(path, "test-utils.jl"))
 
 # create_meta_files(String["catmix", "gasoil", "glider", "methanol", "pinene", "rocket", "steering"])
 function create_meta_files(pb_names::Vector{String}; kwargs...)
@@ -106,6 +106,11 @@ function generate_meta(
   :is_feasible => $(feasible),
   :defined_everywhere => $(missing),
   :origin => :$(origin),
+  :url => \"\",
+  :notes => raw\"\"\"\"\"\",
+  :origin_notes => raw\"\"\"\"\"\",
+  :reference => raw\"\"\"\"\"\",
+  :lib => \"\",
 )
 get_$(name)_nvar(; n::Integer = default_nvar, kwargs...) = $nvar_formula
 get_$(name)_ncon(; n::Integer = default_nvar, kwargs...) = $ncon_formula


### PR DESCRIPTION
## Summary

- **W-SRC-3 / W-DOC-4**: `generate_meta` in `test/utils.jl` was missing five provenance fields introduced after the original 17-field spec. Contributors using `create_meta_files()` to bootstrap a new problem would get a scaffolded meta file that passes CI but silently omits `:url`, `:notes`, `:origin_notes`, `:reference`, and `:lib` — the very fields that the contributing guide emphasises gathering. The generated file now includes all 22 fields, with empty-string / raw-triple-quote defaults as placeholders for the contributor to fill in.

## Changes

### `test/utils.jl`
- Added `:url`, `:notes`, `:origin_notes`, `:reference`, `:lib` to the `generate_meta` Dict template (matching the structure of `src/Meta/arglina.jl`).
- Added an `@isdefined(ndef)` guard around `include("test-utils.jl")` so `utils.jl` can be safely re-included from within the `runtests.jl` context (where `test-utils.jl` is already loaded) without redefining constants.

### `test/test-generate-meta.jl` (new)
Four `@testset`s:
1. All 22 meta keys are present in the generated string (unconstrained problem `arwhead`).
2. All six getter functions (`get_arwhead_{nvar,ncon,nlin,nnln,nequ,nineq}`) are emitted.
3. The generated string is parseable as valid Julia (`Meta.parse`).
4. All 22 keys also present for a constrained problem (`hs7`).

### `test/runtests.jl`
- `include("test-generate-meta.jl")` added before `rmprocs()`.

## Test plan

- [ ] `julia --project test/runtests.jl` — new `@testset "generate_meta: ..."` groups pass
- [ ] Run `generate_meta("arwhead")` manually and confirm the output contains all 22 fields with correct placeholder syntax (`raw""""""`, `""`)
- [ ] Confirm `create_meta_files(["arwhead"])` writes a file that is valid Julia

🤖 Generated with [Claude Code](https://claude.com/claude-code)