### PR TITLE
Fix E-TEST-1: mod → prob in compatibility test guard

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,7 +100,7 @@ include("test-in-place-residual.jl")
     end
   end
 
-  if mod in intersect(list_problems_PureJuMP, list_problems_ADNLPProblems)
+  if prob in intersect(list_problems_PureJuMP, list_problems_ADNLPProblems)
     @testset "Test problems compatibility for $prob" begin
       nlp_jump = make_jump_nlp(prob; n = ndef)
       test_compatibility(prob, nlp_jump, nlp_ad, ndef)


### PR DESCRIPTION
## Summary

One-character fix that re-enables an entire class of tests that have been silently skipped since the guard was written.

## Root cause

In `test/runtests.jl:103`, the condition was:

```julia
if mod in intersect(list_problems_PureJuMP, list_problems_ADNLPProblems)
```

`mod` is not defined inside `test_one_problem` — Julia resolves it to `Base.mod` (the modulo function). The intersection contains `Symbol`s, so `Base.mod in <set of Symbols>` is **always `false`**. The `test_compatibility` call — which checks that ADNLPProblems and PureJuMP agree on objective values, constraint bounds, initial points, and variable counts — was skipped for every single problem on every CI run.

## Fix

```julia
if prob in intersect(list_problems_PureJuMP, list_problems_ADNLPProblems)
```

`prob` is the loop variable passed into `test_one_problem`, which is the correct `Symbol` to check.

## Impact

This re-enables `test_compatibility` for all problems that have both a PureJuMP and an ADNLPProblems implementation (~650+ problems). Expect CI run time to increase as these tests now actually execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)