### PR TITLE
Fix test suite: E-TEST-2, W-TEST-1, W-TEST-3, W-TEST-4

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,5 +112,6 @@ pmap(test_one_problem, list_problems)
 
 include("test-scalable.jl")
 include("test-meta-fields.jl")
+include("test-export-bibtex.jl")
 
 rmprocs()

--- a/test/test-export-bibtex.jl
+++ b/test/test-export-bibtex.jl
@@ -20,5 +20,8 @@ end
   bib_nolibref = tempname() * ".bib"
   export_bibtex(bib_full, include_lib_refs = true)
   export_bibtex(bib_nolibref, include_lib_refs = false)
-  @test filesize(bib_nolibref) <= filesize(bib_full)
+  # NIST_StRD appears only via lib_refs (not in any per-problem :reference field),
+  # so it is a reliable sentinel for whether include_lib_refs was respected.
+  @test occursin("NIST_StRD", read(bib_full, String))
+  @test !occursin("NIST_StRD", read(bib_nolibref, String))
 end

--- a/test/test-export-bibtex.jl
+++ b/test/test-export-bibtex.jl
@@ -1,0 +1,24 @@
+@testset "export_bibtex: basic output" begin
+  bib = tempname() * ".bib"
+  export_bibtex(bib)
+  @test isfile(bib)
+  content = read(bib, String)
+  @test !isempty(content)
+end
+
+@testset "export_bibtex: deduplication" begin
+  bib = tempname() * ".bib"
+  export_bibtex(bib)
+  content = read(bib, String)
+  # arglina cites MoreGarbowHillstrom1981; many MGH problems share this key.
+  # Deduplication must ensure it appears exactly once.
+  @test count("MoreGarbowHillstrom1981", content) == 1
+end
+
+@testset "export_bibtex: include_lib_refs = false omits collection entries" begin
+  bib_full = tempname() * ".bib"
+  bib_nolibref = tempname() * ".bib"
+  export_bibtex(bib_full, include_lib_refs = true)
+  export_bibtex(bib_nolibref, include_lib_refs = false)
+  @test filesize(bib_nolibref) <= filesize(bib_full)
+end

--- a/test/test-export-bibtex.jl
+++ b/test/test-export-bibtex.jl
@@ -1,27 +1,41 @@
 @testset "export_bibtex: basic output" begin
   bib = tempname() * ".bib"
-  export_bibtex(bib)
-  @test isfile(bib)
-  content = read(bib, String)
-  @test !isempty(content)
+  try
+    export_bibtex(bib)
+    @test isfile(bib)
+    content = read(bib, String)
+    @test !isempty(content)
+  finally
+    rm(bib, force = true)
+  end
 end
 
 @testset "export_bibtex: deduplication" begin
   bib = tempname() * ".bib"
-  export_bibtex(bib)
-  content = read(bib, String)
-  # arglina cites MoreGarbowHillstrom1981; many MGH problems share this key.
-  # Deduplication must ensure it appears exactly once.
-  @test count("MoreGarbowHillstrom1981", content) == 1
+  try
+    export_bibtex(bib)
+    content = read(bib, String)
+    # arglina and many other MGH problems share MoreGarbowHillstrom1981.
+    # Count entry headers (not bare key strings) to avoid false matches
+    # inside field values, and verify deduplication keeps exactly one copy.
+    @test count("@article{MoreGarbowHillstrom1981", content) == 1
+  finally
+    rm(bib, force = true)
+  end
 end
 
 @testset "export_bibtex: include_lib_refs = false omits collection entries" begin
   bib_full = tempname() * ".bib"
   bib_nolibref = tempname() * ".bib"
-  export_bibtex(bib_full, include_lib_refs = true)
-  export_bibtex(bib_nolibref, include_lib_refs = false)
-  # NIST_StRD appears only via lib_refs (not in any per-problem :reference field),
-  # so it is a reliable sentinel for whether include_lib_refs was respected.
-  @test occursin("NIST_StRD", read(bib_full, String))
-  @test !occursin("NIST_StRD", read(bib_nolibref, String))
+  try
+    export_bibtex(bib_full, include_lib_refs = true)
+    export_bibtex(bib_nolibref, include_lib_refs = false)
+    # NIST_StRD appears only via lib_refs (not in any per-problem :reference field),
+    # so it is a reliable sentinel for whether include_lib_refs was respected.
+    @test occursin("NIST_StRD", read(bib_full, String))
+    @test !occursin("NIST_StRD", read(bib_nolibref, String))
+  finally
+    rm(bib_full, force = true)
+    rm(bib_nolibref, force = true)
+  end
 end

--- a/test/test-meta-fields.jl
+++ b/test/test-meta-fields.jl
@@ -1,11 +1,11 @@
 """
-    is_valid_url(s) -> Bool
+    is_valid_urls(s) -> Bool
 
 Return `true` if every comma-separated part of `s` is a syntactically valid
 HTTP or HTTPS URL.  A single URL (no commas) is the common case.
 No network request is made; only the structure of each part is checked.
 """
-function is_valid_url(s::String)
+function is_valid_urls(s::String)
   parts = strip.(split(s, ","))
   return all(p -> match(r"^https?://[^\s/$.?#][^\s]*$"i, p) !== nothing, parts)
 end
@@ -38,7 +38,7 @@ end
 @testset "Meta fields: :url format" begin
   invalid = [
     (row[:name], row[:url]) for
-    row in eachrow(OptimizationProblems.meta) if !isempty(row[:url]) && !is_valid_url(row[:url])
+    row in eachrow(OptimizationProblems.meta) if !isempty(row[:url]) && !is_valid_urls(row[:url])
   ]
   for (name, url) in invalid
     @error "Problem $name has an invalid :url format: $url"

--- a/test/test-scalable.jl
+++ b/test/test-scalable.jl
@@ -1,20 +1,14 @@
 @everywhere function test_scalable(item)
-  try
-    name = item.name
-    @testset "Test scalable problems - problem: $(name)" begin
-      nlp = make_nlp(Symbol(name))
-      @test item.nvar == nlp.meta.nvar
-      nlp11 = make_nlp(Symbol(name); n = 13 * ndef)
-      n11 = OptimizationProblems.eval(Symbol(:get_, name, :_nvar))(n = 13 * ndef)
-      @test n11 == nlp11.meta.nvar
+  name = item.name
+  @testset "Test scalable problems - problem: $(name)" begin
+    nlp = make_nlp(Symbol(name))
+    @test item.nvar == nlp.meta.nvar
+    nlp11 = make_nlp(Symbol(name); n = 13 * ndef)
+    n11 = OptimizationProblems.eval(Symbol(:get_, name, :_nvar))(n = 13 * ndef)
+    @test n11 == nlp11.meta.nvar
 
-      # test that the problem is actually scalable
-      @test n11 != item.nvar
-    end
-  catch err
-    @warn "Skipping $(item.name) due to error" err
-    @test !isnothing(err)
-    @test_skip "Skipped $(item.name) due to $(typeof(err))"
+    # test that the problem is actually scalable
+    @test n11 != item.nvar
   end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -211,8 +211,8 @@ function test_linear_constraints(sample_size = 100)
   return list
 end
 
-test_one_problem(pb::String) = test_one_problem(Symbol(pb))
-function test_one_problem(prob::Symbol)
+check_problem(pb::String) = check_problem(Symbol(pb))
+function check_problem(prob::Symbol)
   pb = string(prob)
   @info "Check that $prob is in PureJuMP"
   @test prob in names(PureJuMP)
@@ -247,13 +247,15 @@ function test_one_problem(prob::Symbol)
 end
 
 """
-    is_valid_url(s) -> Bool
+    is_valid_urls(s) -> Bool
 
-Return `true` if `s` is a syntactically valid HTTP or HTTPS URL.
-No network request is made; only the string structure is checked.
+Return `true` if every comma-separated part of `s` is a syntactically valid
+HTTP or HTTPS URL.  A single URL (no commas) is the common case.
+No network request is made; only the structure of each part is checked.
 """
-function is_valid_url(s::String)
-  return match(r"^https?://[^\s/$.?#][^\s]*$"i, s) !== nothing
+function is_valid_urls(s::String)
+  parts = strip.(split(s, ","))
+  return all(p -> match(r"^https?://[^\s/$.?#][^\s]*$"i, p) !== nothing, parts)
 end
 
 """


### PR DESCRIPTION
## Summary

Four test-suite improvements: one error fix that was silently masking wrong URL validation, two code-quality fixes, and one new test for an untested public API.

---

### E-TEST-2 — `is_valid_url` implementations diverge (`test-meta-fields.jl` vs `utils.jl`)

`test-meta-fields.jl` (CI) handled comma-separated multi-URLs correctly; `utils.jl` (contributor manual use) checked only a single URL and returned `false` for any problem with two URLs (e.g. `arglina_meta[:url]` has two URLs separated by a comma).

**Fix:** Renamed both functions to `is_valid_urls` (plural, to signal multi-URL capability) and aligned `utils.jl` to use the same splitting logic as the CI version. Contributors now get the same validation result as CI.

---

### W-TEST-1 — Error-swallowing `try/catch` masks real failures in scalable tests

The `catch` block in `test_scalable` contained `@test !isnothing(err)` which is always `true`. Any real error (MethodError, StackOverflow, …) was logged as a warning and counted as a **passing** test.

**Fix:** Removed the `try/catch` entirely. Genuine failures now propagate as real test failures.

---

### W-TEST-3 — Two functions named `test_one_problem` with different semantics

`runtests.jl` defines a `@everywhere test_one_problem` used in CI via `pmap`. `utils.jl` defines a same-named manual helper for contributor use with different behaviour (includes membership checks, NLS residual tests). Since `utils.jl` is not included in `runtests.jl` there is no runtime conflict, but the shared name caused confusion about which function does what.

**Fix:** Renamed the `utils.jl` version to `check_problem` to make the distinction explicit.

---

### W-TEST-4 — No tests for `export_bibtex`

`export_bibtex` is a public API and key feature for research reproducibility but had zero test coverage.

**Fix:** New `test/test-export-bibtex.jl` with three `@testset`s:
1. Output file is created and non-empty.
2. Deduplication works — `MoreGarbowHillstrom1981` (shared by many MGH problems) appears exactly once.
3. `include_lib_refs = false` produces a smaller file than the default.

## Test plan

- [ ] `julia --project test/runtests.jl` passes, including the three new `export_bibtex` testsets
- [ ] Scalable failures (if any) now surface as genuine test failures instead of silently passing
- [ ] `is_valid_urls("https://a.com, https://b.com")` returns `true` in both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)